### PR TITLE
2B0N End is shown multiple times when replaying

### DIFF
--- a/lib/timeline.js
+++ b/lib/timeline.js
@@ -188,7 +188,8 @@ const proto = {
             }
         } else {
             for (const track of this.tracks()) {
-                for (let child = track.items.firstChild, i = 0; child; child = child.nextSibling, ++i) {
+                for (let child = track.items.firstChild, i = 0; i < track.intervals.length && child;
+                    child = child.nextSibling, ++i) {
                     const [begin, end] = track.intervals[i];
                     const deltaBegin = begin - (begin === end ? SYNC_DELAY_MS : 0) - to;
                     child.classList.toggle("current", deltaBegin < 0 && end > from);

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -124,7 +124,9 @@ const proto = {
         } else {
             // The thread reached its end.
             this.scheduler.scheduleBackward(thread, this.t, this.pc, this.value);
-            notify(this, "op", { thread, t: this.t });
+            if (this.executionMode === Do) {
+                notify(this, "op", { thread, t: this.t });
+            }
         }
     },
 

--- a/tests/timeline.html
+++ b/tests/timeline.html
@@ -40,6 +40,12 @@ test("Add and highlight elements", t => {
 
     vm.clock.seek(3333);
     t.equal(items.children.length, 5, "new content added (last item + end marker)");
+
+    vm.clock.seek(0);
+    t.equal(items.children.length, 5, "items are still there");
+
+    vm.clock.seek(4444);
+    t.equal(items.children.length, 5, "no new items have shown up");
 });
 
 test("Show jump", t => {


### PR DESCRIPTION
Only add the end when DOing, and not REDOing. Also fix a missing check in the timeline when going backwards.