### PR TITLE
2D0B Handle async errors

### DIFF
--- a/examples/images.html
+++ b/examples/images.html
@@ -25,7 +25,7 @@ import { Thread } from "../lib/thread.js";
 const vm = VM().start();
 
 vm.spawn().
-    constant("imageszzz.json").
+    constant("images.json").
     await(url => fetch(url)).
     await(response => response.json()).
     map(Thread().await(([w, h]) => imagePromise(`https://placekitten.com/${w}/${h}`))).

--- a/examples/images.html
+++ b/examples/images.html
@@ -25,7 +25,7 @@ import { Thread } from "../lib/thread.js";
 const vm = VM().start();
 
 vm.spawn().
-    constant("images.json").
+    constant("imageszzz.json").
     await(url => fetch(url)).
     await(response => response.json()).
     map(Thread().await(([w, h]) => imagePromise(`https://placekitten.com/${w}/${h}`))).

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -23,6 +23,12 @@ const proto = {
         return past.sort((a, b) => time.cmp(b.t, a.t) || (b.pc - a.pc))[0]?.value;
     },
 
+    lastTimeOf(thread) {
+        // FIXME 2907 Find an item in a queue (this could be more efficient).
+        const past = this.pastQueue.filter(it => it.thread === thread);
+        return past.sort((a, b) => time.cmp(b.t, a.t) || (b.pc - a.pc))[1]?.t;
+    },
+
     cancel(thread) {
         if (this.unresolved.has(thread)) {
             this.unresolved.delete(thread);
@@ -71,16 +77,10 @@ const proto = {
         return this.pastQueue.insert({ thread, t, pc, value });
     },
 
-    wake(thread, t, value) {
+    wake(thread, t, value, executionMode = Do) {
         console.assert(time.isDefinite(t));
         const pc = mapdel(this.unresolved, thread);
-        return this.scheduleForward(thread, t, pc, value);
-    },
-
-    abort(thread, t, error) {
-        console.assert(time.isDefinite(t));
-        const pc = mapdel(this.unresolved, thread);
-        return this.scheduleForward(thread, t, pc, error, Error);
+        return this.scheduleForward(thread, t, pc, value, executionMode);
     },
 
     dump() {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -7,6 +7,9 @@ import * as time from "./time.js";
 // execution mode (plus Attrs for the timeline).
 export const [Do, Undo, Redo, Attrs] = [0, 1, 2, 3];
 
+// Error is an abnormal behaviour.
+export const Error = Symbol();
+
 const proto = {
     init() {
         this.futureQueue = Queue((a, b) => time.cmp(a.t, b.t) || (a.thread.spawnID - b.thread.spawnID));
@@ -72,6 +75,12 @@ const proto = {
         console.assert(time.isDefinite(t));
         const pc = mapdel(this.unresolved, thread);
         return this.scheduleForward(thread, t, pc, value);
+    },
+
+    abort(thread, t, error) {
+        console.assert(time.isDefinite(t));
+        const pc = mapdel(this.unresolved, thread);
+        return this.scheduleForward(thread, t, pc, error, Error);
     },
 
     dump() {

--- a/lib/style.css
+++ b/lib/style.css
@@ -116,8 +116,16 @@ svg.timeline g.track rect.repeat {
     stroke-dasharray: 4 4;
 }
 
-svg.timeline g.track path.cancel {
-    stroke: #1d2b53;
+svg.timeline g.track path.cancel,
+svg.timeline g.track path.error {
     stroke-width: 4;
     stroke-linecap: round;
+}
+
+svg.timeline g.track path.cancel {
+    stroke: #1d2b53;
+}
+
+svg.timeline g.track path.error {
+    stroke: #ff004d;
 }

--- a/lib/timeline.js
+++ b/lib/timeline.js
@@ -203,7 +203,8 @@ const proto = {
     error(thread, op, t, error) {
         const track = this.tracksById[thread.id];
         const item = track.ops.get(op).get(t);
-        item?.classList.add("error");
+        item.classList.add("error");
+        item.classList.remove("unresolved");
     },
 
     // Threads were spawned with a map.

--- a/lib/timeline.js
+++ b/lib/timeline.js
@@ -203,7 +203,7 @@ const proto = {
     error(thread, op, t, error) {
         const track = this.tracksById[thread.id];
         const item = track.ops.get(op).get(t);
-        item.classList.add("error");
+        item?.classList.add("error");
     },
 
     // Threads were spawned with a map.

--- a/lib/timeline.js
+++ b/lib/timeline.js
@@ -10,6 +10,8 @@ const TRACK_H = 100;
 const REPEAT_H = 60;
 const SYNC_DELAY_MS = 200;
 
+const Error = Symbol();
+
 const proto = {
     init() {
         Object.defineProperty(this, "element", {
@@ -17,7 +19,7 @@ const proto = {
             value: this.createElement()
         });
         on(this.vm, "op", ({ thread, op, t }) => { this.op(thread, op, t); });
-        on(this.vm, "error", ({ thread, op, t, error }) => { this.error(thread, op, t, error); });
+        on(this.vm, "error", event => { this.error(event); });
         on(this.vm, "resolve", ({ thread, t }) => { this.resolved(thread, t); });
         on(this.vm, "cancel", ({ thread, t }) => { this.cancelled(thread, t); });
         on(this.vm, "event", ({ thread }) => { this.resolved(thread, this.vm.clock.now); });
@@ -134,6 +136,8 @@ const proto = {
                 }
             }
             track.x += M;
+        } else if (op === Error) {
+            this.cancelMark(track, "error");
         } else {
             const dur = op[Attrs].dur;
             let item;
@@ -199,12 +203,17 @@ const proto = {
         this.element.style.height = `${this.height / 2}px`;
     },
 
-    // An error occurred while executing an op.
-    error(thread, op, t, error) {
+    // An error occurred while executing an op. If the error is asynchronous,
+    // add an error marker.
+    error(event) {
+        const { thread, op, t, error, asynchronous } = event;
         const track = this.tracksById[thread.id];
         const item = track.ops.get(op).get(t);
         item.classList.add("error");
         item.classList.remove("unresolved");
+        if (asynchronous > 0) {
+            this.op(thread, Error, asynchronous);
+        }
     },
 
     // Threads were spawned with a map.
@@ -244,11 +253,16 @@ const proto = {
             track.x = this.currentTimeInterval[1];
             track.t = t;
         }
+        this.cancelMark(track);
+    },
+
+    // Add a cancel mark at the end of a track.
+    cancelMark(track, className = "cancel") {
         const x = track.x;
         const y = track.y;
         const m = M / 3;
         track.support.appendChild(svg("path", {
-            class: "cancel",
+            class: className,
             d: `M${x - m},${y - m}L${x + m},${y + m}M${x - m},${y + m}L${x + m},${y - m}`
         }));
     },

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -2,7 +2,7 @@ import { notify, on } from "./events.js";
 import { create, del, get, geto } from "./util.js";
 import { Broken, Clock } from "./clock.js";
 import { Thread } from "./thread.js";
-import { Scheduler, Do, Undo, Redo } from "./scheduler.js";
+import { Scheduler, Do, Undo, Redo, Error } from "./scheduler.js";
 import * as time from "./time.js";
 
 // Unique value for timeouts.
@@ -112,12 +112,17 @@ const proto = {
         this.unpackScheduleItem(scheduleItem);
         console.assert(this.executionMode !== Undo);
         while (this.pc < n && !this.yielded) {
-            const op = thread.ops[this.pc++];
+            let op = thread.ops[this.pc++];
             if (this.executionMode === Do) {
                 notify(this, "op", { thread, op, t: this.t });
             }
             try {
-                op[this.executionMode](thread, this);
+                if (this.executionMode === Error) {
+                    op = thread.ops[(this.pc + n - 2) % n];
+                    throw this.value;
+                } else {
+                    op[this.executionMode](thread, this);
+                }
             } catch (error) {
                 this.error(thread, op, error);
                 this.scheduler.scheduleBackward(thread, this.t, this.pc, error);
@@ -225,6 +230,9 @@ const proto = {
         f(this.value, this.t).then(value => {
             this.scheduler.wake(thread, this.clock.now, value);
             notify(this, "await", { thread, value });
+        }).catch(error => {
+            this.scheduler.abort(thread, this.clock.now, error);
+            notify(this, "await", { thread, error });
         });
         this.delay(thread, time.unresolved);
     },

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -243,6 +243,7 @@ const proto = {
             notify(this, "await", { thread, value });
         }).catch(error => {
             this.scheduler.wake(thread, this.clock.now, { error, t }, Error);
+            notify(this, "await", { thread, error });
         });
         this.delay(thread, time.unresolved);
     },

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -97,7 +97,9 @@ const proto = {
         }
         console.assert(time.cmp(this.scheduler.nextFutureTime, from) >= 0);
         while (this.scheduler.hasFuture && this.scheduler.nextFutureTime < to) {
-            this.runForward(this.scheduler.nextFutureItem);
+            if (!this.runForward(this.scheduler.nextFutureItem)) {
+                break;
+            }
         }
     },
 
@@ -112,9 +114,11 @@ const proto = {
         const n = thread.ops.length;
         this.unpackScheduleItem(scheduleItem);
         console.assert(this.executionMode !== Undo);
+
+        // Pending asynchronous error.
         if (this.executionMode === Error) {
             const op = thread.ops[(this.pc + n - 1) % n];
-            this.error(thread, op, this.value.t, this.value.error);
+            this.error(thread, op, this.value.t, this.value.error, true);
             this.scheduler.scheduleBackward(thread, this.t, this.pc, this.value.error);
             return;
         }
@@ -144,6 +148,9 @@ const proto = {
                 thread.parent?.childThreadDidEnd(thread, this);
             }
         }
+
+        // End normally.
+        return true;
     },
 
     // Run updates backward (undo).
@@ -182,8 +189,8 @@ const proto = {
     },
 
     // An error occurred when executing `op`.
-    error(thread, op, t, error) {
-        notify(this, "error", { thread, op, t, error });
+    error(thread, op, t, error, asynchronous = false) {
+        notify(this, "error", { thread, op, t, error, asynchronous: asynchronous && this.t });
         if (error.message) {
             console.error(`Error: ${error.message}`);
         } else {

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -107,24 +107,27 @@ const proto = {
         if (scheduleItem.cancelled) {
             return;
         }
+
         const thread = scheduleItem.thread;
         const n = thread.ops.length;
         this.unpackScheduleItem(scheduleItem);
         console.assert(this.executionMode !== Undo);
+        if (this.executionMode === Error) {
+            const op = thread.ops[(this.pc + n - 1) % n];
+            this.error(thread, op, this.value.t, this.value.error);
+            this.scheduler.scheduleBackward(thread, this.t, this.pc, this.value.error);
+            return;
+        }
+
         while (this.pc < n && !this.yielded) {
             let op = thread.ops[this.pc++];
             if (this.executionMode === Do) {
                 notify(this, "op", { thread, op, t: this.t });
             }
             try {
-                if (this.executionMode === Error) {
-                    op = thread.ops[(this.pc + n - 2) % n];
-                    throw this.value;
-                } else {
-                    op[this.executionMode](thread, this);
-                }
+                op[this.executionMode](thread, this);
             } catch (error) {
-                this.error(thread, op, error);
+                this.error(thread, op, this.t, error);
                 this.scheduler.scheduleBackward(thread, this.t, this.pc, error);
                 return;
             }
@@ -164,7 +167,7 @@ const proto = {
             try {
                 op[Undo](thread, this);
             } catch (error) {
-                this.error(thread, op, error);
+                this.error(thread, op, this.t, error);
                 this.scheduler.scheduleForward(thread, this.t, this.pc, this.value, Redo);
                 return;
             }
@@ -179,8 +182,8 @@ const proto = {
     },
 
     // An error occurred when executing `op`.
-    error(thread, op, error) {
-        notify(this, "error", { thread, op, t: this.t, error });
+    error(thread, op, t, error) {
+        notify(this, "error", { thread, op, t, error });
         if (error.message) {
             console.error(`Error: ${error.message}`);
         } else {
@@ -227,12 +230,12 @@ const proto = {
 
     // Asynchronous function call.
     await(thread, f) {
+        const t = this.t;
         f(this.value, this.t).then(value => {
             this.scheduler.wake(thread, this.clock.now, value);
             notify(this, "await", { thread, value });
         }).catch(error => {
-            this.scheduler.abort(thread, this.clock.now, error);
-            notify(this, "await", { thread, error });
+            this.scheduler.wake(thread, this.clock.now, { error, t }, Error);
         });
         this.delay(thread, time.unresolved);
     },

--- a/tests/timeline.html
+++ b/tests/timeline.html
@@ -7,6 +7,7 @@
         <script type="module">
 
 import { test } from "./test.js";
+import { notification } from "../lib/events.js";
 import { K, nop } from "../lib/util.js";
 import { Timeline } from "../lib/timeline.js";
 import { VM } from "../lib/vm.js";
@@ -164,6 +165,22 @@ test("Error (undo)", t => {
     vm.clock.seek(72);
     t.errors(() => { vm.clock.seek(0); }, "error message in the console");
     t.equal(timeline.element.querySelectorAll("circle.error").length, 1, "error item");
+});
+
+test("Error(async)", async t => {
+    const vm = VM();
+    const timeline = Timeline(vm);
+
+    vm.spawnAt(17).
+        await(() => new Promise((_, reject) => { setTimeout(() => { reject("async failure"); }, 0); })).
+        effect(() => { throw Error("!!!"); });
+
+    vm.clock.seek(18);
+    await notification(vm, "await");
+    t.errors(() => { vm.clock.seek(23); }, "error message in the console");
+    t.equal(timeline.element.querySelectorAll("g.times rect").length, 3, "3 time intervals");
+    t.equal(timeline.element.querySelectorAll("rect.error").length, 1, "error item");
+    t.equal(timeline.element.querySelectorAll("path.error").length, 1, "error mark");
 });
 
         </script>

--- a/tests/vm.html
+++ b/tests/vm.html
@@ -222,6 +222,19 @@ test("Bail on error (redo)", t => {
     // t.equal(vm.valueOf(thread) instanceof Error, true, "thread error (redo)");
 });
 
+test("Bail on error (async)", async t => {
+    const vm = VM();
+    const thread = vm.spawnAt(17).
+        await(() => new Promise((_, reject) => { setTimeout(() => { reject("async failure"); }, 0); })).
+        effect(() => { throw Error("!!!"); });
+    vm.clock.seek(18);
+    const { error } = await notification(vm, "await")
+    t.equal(error, "async failure", "error notification");
+    t.errors(() => { vm.clock.seek(23); }, "error message");
+    // FIXME 2D05 Review valueOf(thread) when going backward
+    // t.equal(vm.valueOf(thread) instanceof Error, true, "thread error (async)");
+});
+
         </script>
     </head>
     <body>


### PR DESCRIPTION
Handle async errors by keeping track of the begin time of the offending op so that it can be marked, and surface the error in the next update—then bail. A mark is added to the timeline as well to visualise when the error occurred.