### PR TITLE
2D0E VM keepAlive option

### DIFF
--- a/examples/timeline.html
+++ b/examples/timeline.html
@@ -14,7 +14,7 @@ import { Thread } from "../lib/thread.js";
 
 // ----8<--------8<--------8<--------8<--------8<--------8<--------8<----
 
-const vm = VM().start();
+const vm = VM().start().keepAlive();
 document.body.appendChild(TransportBar(vm).element);
 document.body.appendChild(Timeline(vm).element);
 

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -41,6 +41,10 @@ const proto = {
         }
     },
 
+    get isIdle() {
+        return this.futureQueue.length === 0 && this.unresolved.size === 0;
+    },
+
     get hasFuture() {
         return this.futureQueue.length > 0;
     },

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -48,6 +48,12 @@ const proto = {
         return this.scheduler.valueOf(thread);
     },
 
+    // Set keepAlive to true so that the VM does not stop even when idle.
+    keepAlive() {
+        this._keepAlive = true;
+        return this;
+    },
+
     saveProperty(object, property) {
         const properties = get(this.values, object, () => ({}));
         const values = geto(properties, property, () => ([]));
@@ -93,6 +99,9 @@ const proto = {
     // Run updates forward (do/redo).
     updateForward(from, to) {
         if (!this.scheduler.hasFuture) {
+            if (!this._keepAlive && this.scheduler.isIdle) {
+                this.clock.pause();
+            }
             return;
         }
         console.assert(time.cmp(this.scheduler.nextFutureTime, from) >= 0);

--- a/tests/vm.html
+++ b/tests/vm.html
@@ -23,6 +23,24 @@ test("Start the clock", async t => {
     t.above(vm.clock.now, 0, `clock started (${vm.clock.now})`);
 });
 
+test("keepAlive (off by default)", async t => {
+    const vm = VM().start();
+    const thread = vm.spawn().event(window, "synth").constant("ok");
+    await notification(vm.clock, "update");
+    t.equal(vm.clock.paused, false, "clock still running (scheduler is not idle)");
+    window.dispatchEvent(new window.Event("synth"));
+    await notification(vm.clock, "update");
+    t.equal(vm.valueOf(thread), "ok", "thread ended normally");
+    await notification(vm.clock, "update");
+    t.equal(vm.clock.paused, true, "clock paused (scheduler is idle)");
+});
+
+test("keepAlive()", async t => {
+    const vm = VM().start().keepAlive();
+    await notification(vm.clock, "update");
+    t.equal(vm.clock.paused, false, "clock still running (scheduler is idle)");
+});
+
 test("spawn(t = now)", t => {
     const vm = VM();
     const thread = vm.spawn();


### PR DESCRIPTION
The VM pauses its clock by default if the scheduler is idle, i.e., no thread is scheduled in the future. This behaviour can be overridden with the `.keepAlive()` option on the VM (which can only be set though.)