### PR TITLE
2A01 Alarm

### DIFF
--- a/examples/timeline.html
+++ b/examples/timeline.html
@@ -11,6 +11,7 @@ import { VM } from "../lib/vm.js";
 import { TransportBar } from "../lib/transport-bar.js";
 import { Timeline } from "../lib/timeline.js";
 import { Thread } from "../lib/thread.js";
+import { show } from "../lib/show.js";
 
 // ----8<--------8<--------8<--------8<--------8<--------8<--------8<----
 
@@ -21,11 +22,9 @@ document.body.appendChild(Timeline(vm).element);
 vm.spawn().
     delay(500).
     constant(["1.8s", "1.3s", "2.1s"]).
-    map(Thread().delay()).
-    spawn(Thread().constant("1.4s").delay()).
-    first().
-    delay("1.5s").
-    effect(v => { console.log(`Ended with ${v}`); });
+    map(Thread().delay().instant(dur => `Waited for ${dur}`)).
+    joinThread(Thread().delay("1.9s"), false).
+    effect(v => { console.log(`Ended with ${show(v)}`); });
 
 // ----8<--------8<--------8<--------8<--------8<--------8<--------8<----
 

--- a/lib/thread.js
+++ b/lib/thread.js
@@ -10,6 +10,9 @@ const Static = Symbol();
 const Dynamic = Symbol();
 const First = Symbol();
 
+// Special timeout value.
+export const Timeout = Symbol.for("timeout");
+
 const proto = {
     // Convenience function to push an op that has no undo or redo.
     do(op, attrs) {
@@ -194,6 +197,23 @@ const proto = {
         }, { tag: "join", dur: time.unresolved });
     },
 
+    // Spawn and thread and join it, cancelling all the other children
+    joinThread(childThread, cancelChildren = true, storeValues = true) {
+        return this.asyncdo((parentThread, vm) => {
+            parentThread.children.push(childThread);
+            childThread.parent = parentThread;
+            vm.spawnChild(childThread, vm.value);
+            parentThread.join = {
+                type: Static,
+                values: storeValues ? [] : Ignore,
+                interrupt: !cancelChildren,
+                pending: childThread,
+                cancellable: new Set(parentThread.children)
+            };
+            vm.delay(parentThread, time.unresolved);
+        }, { tag: "join/thread", dur: time.unresolved, childThread });
+    },
+
     // Dynamic join: end with values in the order in which the threads ended.
     joinDynamic(storeValues = true) {
         return this.asyncdo((thread, vm) => {
@@ -241,15 +261,23 @@ const proto = {
                 }
             }
             this.join.cancellable?.delete(childThread);
-            if (--this.join.pending === 0) {
+            if ((this.join.pending > 0 && --this.join.pending === 0) ||
+                (this.join.pending === childThread)) {
                 if (this.join.cancellable) {
                     for (const child of this.join.cancellable.values()) {
                         vm.cancel(child);
+                        if (this.join.type === Static) {
+                            this.join.values[this.children.indexOf(child)] = this.join.interrupt ?
+                                vm.valueOf(child) : Timeout;
+                        }
                     }
                 }
                 const value = Array.isArray(this.join.values) ?
                     (this.join.type === First ? this.join.values[0] : this.join.values) :
                     vm.valueOf(this);
+                if (this.join.pending === childThread) {
+                    value.pop();
+                }
                 delete this.join;
                 this.children = [];
                 vm.childThreadsDidJoin(this, value);

--- a/lib/timeline.js
+++ b/lib/timeline.js
@@ -194,7 +194,6 @@ const proto = {
         this.element.style.height = `${this.height / 2}px`;
     },
 
-
     // An error occurred while executing an op. If the error is asynchronous,
     // add an error marker.
     error(event) {

--- a/lib/timeline.js
+++ b/lib/timeline.js
@@ -154,21 +154,9 @@ const proto = {
                             width: track.x - x, height: REPEAT_H
                         }));
                         break;
-                    case "spawn": {
-                        const j = op[Attrs].childThread.id;
-                        const childTrack = this.tracksById[j];
-                        if (childTrack) {
-                            track.support.appendChild(svg("line", {
-                                "marker-end": "url(#arrow)",
-                                x1: track.x, x2: track.x,
-                                y1: track.y + R, y2: childTrack.y - R / 2
-                            }));
-                            childTrack.x = track.x + 2 * M;
-                        } else {
-                            this.spawnsById[j] = [track.x, track.y];
-                        }
+                    case "spawn":
+                        this.addSpawnArrow(track, op);
                         break;
-                    }
                     case "map":
                         track.spawnX = track.x;
                         break;
@@ -181,6 +169,9 @@ const proto = {
                 }));
                 if (dur === null) {
                     item.classList.add("unresolved");
+                }
+                if (op[Attrs].tag === "join/thread") {
+                    this.addSpawnArrow(track, op, M / 2);
                 }
                 track.x += M + DELAY_W;
             }
@@ -203,6 +194,7 @@ const proto = {
         this.element.style.height = `${this.height / 2}px`;
     },
 
+
     // An error occurred while executing an op. If the error is asynchronous,
     // add an error marker.
     error(event) {
@@ -223,6 +215,22 @@ const proto = {
             this.spawnsById[child.id] = [track.spawnX, track.y];
         }
         delete track.spawnX;
+    },
+
+    // Add a spawn arrow from an op on a track to the track of the child thread.
+    addSpawnArrow(track, op, offset = 0) {
+        const j = op[Attrs].childThread.id;
+        const childTrack = this.tracksById[j];
+        if (childTrack) {
+            track.support.appendChild(svg("line", {
+                "marker-end": "url(#arrow)",
+                x1: track.x + offset, x2: track.x + offset,
+                y1: track.y + R, y2: childTrack.y - R / 2
+            }));
+            childTrack.x = track.x + 2 * M + offset;
+        } else {
+            this.spawnsById[j] = [track.x + offset, track.y];
+        }
     },
 
     // An end time was resolved (thread woke or delay become resolved).

--- a/tests/thread.html
+++ b/tests/thread.html
@@ -8,7 +8,7 @@
 
 import { test } from "./test.js";
 import { notification } from "../lib/events.js";
-import { Thread } from "../lib/thread.js";
+import { Thread, Timeout } from "../lib/thread.js";
 import { K, svg } from "../lib/util.js";
 import { VM } from "../lib/vm.js";
 
@@ -186,6 +186,38 @@ test("join(ignoreValues)", t => {
         join(false);
     vm.clock.seek(49);
     t.equal(vm.valueOf(thread), "ok", "ignored values");
+});
+
+test("joinThread(thread)", t => {
+    const vm = VM();
+    const thread = vm.spawnAt(17).
+        spawn(Thread().constant("ok")).
+        joinThread(Thread().delay(23)).
+        instant((xs, t) => [xs, t]);
+    vm.clock.seek(41);
+    t.equal(vm.valueOf(thread), [["ok"], 40], "extended duration");
+});
+
+test("joinThread(thread)", t => {
+    const vm = VM();
+    const thread = vm.spawnAt(17).
+        spawn(Thread().constant("A").delay(19)).
+        spawn(Thread().constant("B").delay(31)).
+        joinThread(Thread().delay(23)).
+        instant((xs, t) => [xs, t]);
+    vm.clock.seek(41);
+    t.equal(vm.valueOf(thread), [["A", Timeout], 40], "shortened duration");
+});
+
+test("joinThread(thread, false)", t => {
+    const vm = VM();
+    const thread = vm.spawnAt(17).
+        spawn(Thread().constant("A-").delay(19).constant("A+")).
+        spawn(Thread().constant("B-").delay(31).constant("B+")).
+        joinThread(Thread().delay(23), false).
+        instant((xs, t) => [xs, t]);
+    vm.clock.seek(41);
+    t.equal(vm.valueOf(thread), [["A+", "B-"], 40], "interrupted children");
 });
 
 test("joinDynamic()", t => {

--- a/tests/timeline.html
+++ b/tests/timeline.html
@@ -111,6 +111,21 @@ test("Join threads", t => {
     t.equal(timeline.element.querySelectorAll("line[marker-end]").length, 2, "two arrows");
 });
 
+test("Join threads (joinThread)", t => {
+    const vm = VM();
+    const timeline = Timeline(vm);
+
+    const thread = vm.spawnAt(17).
+        spawn(Thread().constant("A-").delay(19).constant("A+")).
+        spawn(Thread().constant("B-").delay(31).constant("B+")).
+        joinThread(Thread().delay(23), false).
+        instant((xs, t) => [xs, t]);
+
+    vm.clock.seek(41);
+    t.equal(timeline.element.querySelectorAll("line[marker-end]").length, 5, "5 arrows (3 ups, 2 down)");
+    t.equal(timeline.element.querySelectorAll("path.cancel").length, 1, "1 cancel");
+});
+
 test("Join threads (first)", t => {
     const vm = VM();
     const timeline = Timeline(vm);


### PR DESCRIPTION
Introduce joinThread() which spawns a thread and immediately wait to join on said thread. The child threads still running when the alarm thread ends can either be cancelled (default) or simply interrupted. The result value is similar to a static join not including the alarm thread; when cancelled, threads have a special Timeout value, while interrupted threads just have whatever value they had when the alarm occurred. This allows a simple implementation of duration; first and join can implement max an min duration.