### PR TITLE
2D0I Timeline: show whether an op sets a new value

### DIFF
--- a/lib/style.css
+++ b/lib/style.css
@@ -84,9 +84,22 @@ svg.timeline g.track line {
     stroke: #1d2b53;
 }
 
+svg.timeline g.track circle.effect,
+svg.timeline g.track rect.effect {
+    stroke: #1d2b53;
+    stroke-width: 3;
+    fill: none;
+}
+
 svg.timeline g.track circle,
 svg.timeline g.track rect {
     fill: #1d2b53;
+}
+
+svg.timeline g.track circle.effect.current,
+svg.timeline g.track rect.effect.current {
+    fill: none;
+    stroke: #008751;
 }
 
 svg.timeline g.track circle.current,
@@ -101,8 +114,19 @@ svg.timeline g.track circle.current.end {
     stroke-width: 3;
 }
 
+svg.timeline g.track rect.effect.current.unresolved {
+    fill: none;
+    stroke: #00e436;
+}
+
 svg.timeline g.track rect.current.unresolved {
     fill: #00e436;
+}
+
+svg.timeline g.track circle.effect.error,
+svg.timeline g.track rect.effect.error {
+    fill: none;
+    stroke: #ff004d;
 }
 
 svg.timeline g.track circle.error,

--- a/lib/thread.js
+++ b/lib/thread.js
@@ -13,6 +13,9 @@ const First = Symbol();
 // Special timeout value.
 export const Timeout = Symbol.for("timeout");
 
+// Effect flag for attributes.
+const effect = true;
+
 const proto = {
     // Convenience function to push an op that has no undo or redo.
     do(op, attrs) {
@@ -56,7 +59,7 @@ const proto = {
             undo(vm.value, vm.t - thread.begin);
         }, (thread, vm) => {
             redo(vm.value, vm.t - thread.begin);
-        }, { tag: "effect", dur: 0 }]);
+        }, { tag: "effect", dur: 0, effect }]);
         return this;
     },
 
@@ -64,7 +67,7 @@ const proto = {
     halt() {
         return this.doUndo((thread, vm) => {
             vm.pc = thread.ops.length;
-        }, nop, { tag: "halt", dur: 0 });
+        }, nop, { tag: "halt", dur: 0, effect });
     },
 
     // Asynchronous computation.
@@ -79,7 +82,7 @@ const proto = {
     delay(dur) {
         return this.asyncdo((thread, vm) => {
             vm.delay(thread, vm.t + time.read(dur ?? vm.value), dur == null);
-        }, { tag: "delay", dur: dur == null ? null : time.read(dur) });
+        }, { tag: "delay", dur: dur == null ? null : time.read(dur), effect });
     },
 
     // Set an object property.
@@ -89,7 +92,7 @@ const proto = {
             object[property] = vm.value;
         }, (_, vm) => {
             vm.restoreProperty(object, property);
-        }, { tag: "set", dur: 0 });
+        }, { tag: "set", dur: 0, effect });
     },
 
     // Unset an object property (revert the previously saved value, if any).
@@ -99,7 +102,7 @@ const proto = {
         }, (_, vm) => {
             vm.saveProperty(object, property);
             object[property] = vm.value;
-        }, { tag: "unset", dur: 0 });
+        }, { tag: "unset", dur: 0, effect });
     },
 
     // Set an element attribute.
@@ -109,7 +112,7 @@ const proto = {
             element.setAttribute(attribute, vm.value);
         }, (_, vm) => {
             vm.restoreAttribute(element, attribute);
-        }, { tag: "set/attribute", dur: 0 });
+        }, { tag: "set/attribute", dur: 0, effect });
     },
 
     // Unset an element attribute, reverting to the previously saved value.
@@ -119,7 +122,7 @@ const proto = {
         }, (_, vm) => {
             vm.saveAttribute(element, attribute);
             element.setAttribute(attribute, vm.value);
-        }, { tag: "unset/attribute", dur: 0 });
+        }, { tag: "unset/attribute", dur: 0, effect });
     },
 
     // (DOM) Event; options are boolean flags to call for preventDefault,
@@ -148,7 +151,7 @@ const proto = {
                     vm.pc = thread.repeats.at(-1)[1];
                 }
             },
-            { tag: "repeat", dur: 0 }
+            { tag: "repeat", dur: 0, effect }
         );
     },
 
@@ -158,7 +161,7 @@ const proto = {
         return this.doUndo(
             (thread, vm) => { vm.pc = thread.repeats.at(-1)[0]; },
             nop,
-            { tag: "loop", dur: 0 }
+            { tag: "loop", dur: 0, effect }
         );
     },
 
@@ -168,7 +171,7 @@ const proto = {
             parentThread.children.push(childThread);
             childThread.parent = parentThread;
             vm.spawnChild(childThread, vm.value);
-        }, { tag: "spawn", dur: 0, childThread });
+        }, { tag: "spawn", dur: 0, childThread, effect });
     },
 
     // Spawn a copy of the child thread for every input.
@@ -183,7 +186,7 @@ const proto = {
                 vm.spawnChild(instance, value);
             }
             notify(vm, "spawns", { parentThread, childThreads: parentThread.children.slice(i) });
-        }, { tag: "map", dur: 0 });
+        }, { tag: "map", dur: 0, effect });
     },
 
     // Static join: wait for all threads to finish and keep track of their
@@ -201,7 +204,7 @@ const proto = {
                 };
                 vm.delay(thread, time.unresolved);
             }
-        }, { tag: "join", dur: time.unresolved });
+        }, { tag: "join", dur: time.unresolved, effect: !storeValues });
     },
 
     // Spawn and thread and join it, cancelling all the other children
@@ -218,7 +221,7 @@ const proto = {
                 cancellable: new Set(parentThread.children)
             };
             vm.delay(parentThread, time.unresolved);
-        }, { tag: "join/thread", dur: time.unresolved, childThread });
+        }, { tag: "join/thread", dur: time.unresolved, childThread, effect: !storeValues });
     },
 
     // Dynamic join: end with values in the order in which the threads ended.
@@ -234,7 +237,7 @@ const proto = {
                 };
                 vm.delay(thread, time.unresolved);
             }
-        }, { tag: "join/dynamic", dur: time.unresolved });
+        }, { tag: "join/dynamic", dur: time.unresolved, effect: !storeValues });
     },
 
     // First: end as soon as a thread ends and cancel all the others.
@@ -251,7 +254,7 @@ const proto = {
                 };
                 vm.delay(thread, time.unresolved);
             }
-        }, { tag: "join/first", dur: time.unresolved });
+        }, { tag: "join/first", dur: time.unresolved, effect: !storeValue });
     },
 
     // When a child thread has ended, check the current join status of the

--- a/lib/timeline.js
+++ b/lib/timeline.js
@@ -139,12 +139,13 @@ const proto = {
         } else if (op === Error) {
             this.cancelMark(track, "error");
         } else {
-            const dur = op[Attrs].dur;
+            const { dur, effect, tag } = op[Attrs];
             let item;
             if (dur === 0) {
                 track.intervals.push([t, t]);
                 item = track.items.appendChild(svg("circle", { cx: track.x, cy: track.y, r: R }));
-                switch (op[Attrs].tag) {
+                item.classList.toggle("effect", !!effect);
+                switch (tag) {
                     case "loop":
                         const [j, k] = thread.repeats.at(-1);
                         console.assert(j < k);
@@ -167,6 +168,7 @@ const proto = {
                 item = track.items.appendChild(svg("rect", {
                     x: track.x, y: track.y - R, width: DELAY_W, height: 2 * R
                 }));
+                item.classList.toggle("effect", !!effect);
                 if (dur === null) {
                     item.classList.add("unresolved");
                 }

--- a/tests/timeline.html
+++ b/tests/timeline.html
@@ -49,6 +49,23 @@ test("Add and highlight elements", t => {
     t.equal(items.children.length, 3, "no new items have shown up");
 });
 
+test("Effect vs. value", t => {
+    const vm = VM();
+    const timeline = Timeline(vm);
+
+    vm.spawn().
+        constant("ok?").
+        effect(nop).
+        delay("3.3s").
+        await(() => new Promise(nop));
+
+    vm.clock.seek(3333);
+    const track = timeline.element.querySelector("g.track");
+    const items = [...track.querySelectorAll("circle, rect")];
+    t.equal(items.map(item => item.classList.contains("effect")), [false, true, true, false],
+        "constant and await are values, effect and delay are effects");
+});
+
 test("Show jump", t => {
     const vm = VM();
     const timeline = Timeline(vm);


### PR DESCRIPTION
Effects, which don’t affect the value of the thread, are shown empty whereas value ops are filled.