### PR TITLE
2G03 Replace Event with Receive

### DIFF
--- a/examples/counter.html
+++ b/examples/counter.html
@@ -24,8 +24,8 @@ vm.spawn().
     repeat().
     set(span, "textContent").
     spawn(Thread().
-        spawn(Thread().event(plus, "click").constant(1)).
-        spawn(Thread().event(minus, "click").constant(-1)).
+        spawn(Thread().receive(plus, "click").constant(1)).
+        spawn(Thread().receive(minus, "click").constant(-1)).
         first()
     ).
     spawn(Thread()).

--- a/examples/timeline.html
+++ b/examples/timeline.html
@@ -15,7 +15,7 @@ import { show } from "../lib/show.js";
 
 // ----8<--------8<--------8<--------8<--------8<--------8<--------8<----
 
-const vm = VM().start().keepAlive();
+const vm = VM().start();
 document.body.appendChild(TransportBar(vm).element);
 document.body.appendChild(Timeline(vm).element);
 

--- a/examples/transport-bar.html
+++ b/examples/transport-bar.html
@@ -12,7 +12,7 @@ import { VM } from "../lib/vm.js";
 
 // ----8<--------8<--------8<--------8<--------8<--------8<--------8<----
 
-const vm = VM().start();
+const vm = VM().start().keepAlive();
 const transportBar = TransportBar(vm);
 document.body.appendChild(transportBar.element);
 

--- a/lib/thread.js
+++ b/lib/thread.js
@@ -128,33 +128,33 @@ const proto = {
         }, { tag: "unset/attribute", dur: 0, effect });
     },
 
-    // (DOM) Event; options are boolean flags to call for preventDefault,
-    // stopImmediatePropagation and/or stopPropagation when the event is
-    // handled.
-    event(target, type, options = {}) {
-        this.ops.push([(thread, vm) => {
-            vm.listen(thread, target, type, options);
-        }, (thread, vm) => {
-            if (thread.currentEventListener?.target === target &&
-                thread.currentEventListener?.type === type) {
-                target.removeEventListener(type, del(thread, "currentEventListener").handler);
-            }
-            vm.yield(thread);
-        }, yields, { tag: "event", dur: time.unresolved }]);
-        return this;
-    },
-
-    // Receive an internal event.
-    receive(target, type) {
-        this.ops.push([(thread, vm) => {
-            vm.receive(thread, target, type);
-        }, (thread, vm) => {
-            if (thread.currentEventListener?.target === target &&
-                thread.currentEventListener?.type === type) {
-                off(target, type, del(thread, "currentEventListener").handler);
-            }
-            vm.yield(thread);
-        }, yields, { tag: "receive", dur: time.unresolved }]);
+    // Receive an internal or a DOM event. Options are boolean flags to call
+    // for preventDefault, stopImmediatePropagation and/or stopPropagation when
+    // the DOM event is handled. Set the `dom` option to false when the target
+    // of an internal event can also be a DOM event target.
+    receive(target, type, options = {}) {
+        if (typeof target.addEventListener === "function" && options.dom !== false) {
+            this.ops.push([(thread, vm) => {
+                vm.addEventListener(thread, target, type, options);
+            }, (thread, vm) => {
+                if (thread.currentEventListener?.target === target &&
+                    thread.currentEventListener?.type === type) {
+                    target.removeEventListener(type, del(thread, "currentEventListener").handler);
+                }
+                vm.yield(thread);
+            }, yields, { tag: "event", dur: time.unresolved }]);
+            return this;
+        } else {
+            this.ops.push([(thread, vm) => {
+                vm.receive(thread, target, type);
+            }, (thread, vm) => {
+                if (thread.currentEventListener?.target === target &&
+                    thread.currentEventListener?.type === type) {
+                    off(target, type, del(thread, "currentEventListener").handler);
+                }
+                vm.yield(thread);
+            }, yields, { tag: "receive", dur: time.unresolved }]);
+        }
         return this;
     },
 

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -1,4 +1,4 @@
-import { notify, on, once } from "./events.js";
+import { notify, on, off, once } from "./events.js";
 import { create, del, get, geto } from "./util.js";
 import { Broken, Clock } from "./clock.js";
 import { Thread } from "./thread.js";
@@ -235,8 +235,9 @@ const proto = {
         }
     },
 
-    // Suspend the thread and start listening to the event.
-    listen(thread, target, type, options) {
+    // Suspend the thread and start listening to a DOM event.
+    addEventListener(thread, target, type, options) {
+        this.delay(thread, time.unresolved);
         const handler = event => {
             console.assert(thread.currentEventListener);
             target.removeEventListener(type, del(thread, "currentEventListener").handler);
@@ -252,12 +253,11 @@ const proto = {
             this.scheduler.wake(thread, this.clock.now, event);
             notify(this, "event", { thread, event });
         };
-        this.delay(thread, time.unresolved);
         target.addEventListener(type, handler);
-        thread.currentEventListener = { target, type, handler };
+        thread.currentEventListener = { target, type, handler, dom: true };
     },
 
-    // Suspend the thread and start listening to the internal event.
+    // Suspend the thread and start listening to an internal event.
     receive(thread, target, type) {
         this.delay(thread, time.unresolved);
         thread.currentEventListener = {
@@ -265,6 +265,7 @@ const proto = {
             type,
             handler: once(target, type, event => {
                 console.assert(thread.currentEventListener);
+                delete thread.currentEventListener;
                 this.scheduler.wake(thread, this.clock.now, event);
                 notify(this, "receive", { thread, event });
             })
@@ -303,8 +304,12 @@ const proto = {
         this.scheduler.cancel(thread);
         notify(this, "cancel", { thread, t: this.t });
         if (thread.currentEventListener) {
-            const { target, type, handler } = del(thread, "currentEventListener");
-            target.removeEventListener(type, handler);
+            const { target, type, handler, dom } = del(thread, "currentEventListener");
+            if (dom) {
+                target.removeEventListener(type, handler);
+            } else {
+                off(target, type, handler);
+            }
         }
         if (thread.cancellable) {
             for (const child of thread.cancellable.values()) {

--- a/tests/thread.html
+++ b/tests/thread.html
@@ -119,10 +119,9 @@ test("setAttribute/unsetAttribute(element, attribute)", t => {
     t.equal(vm.valueOf(thread), "M100,50", "thread value (set is an effect)");
 });
 
-test("event(target, type)", t => {
+test("receive(target, type); DOM event", t => {
     const vm = VM();
-    const thread = vm.spawnAt(17);
-    thread.event(window, "synth");
+    const thread = vm.spawnAt(17).receive(window, "synth");
     vm.clock.seek(31);
     const event = new window.Event("synth");
     window.dispatchEvent(event);
@@ -131,10 +130,9 @@ test("event(target, type)", t => {
     t.equal(vm.valueOf(thread), event, "event value");
 });
 
-test("receive(target, type)", t => {
+test("receive(target, type); internal event", t => {
     const vm = VM();
-    const thread = vm.spawnAt(17).
-        receive(window, "synth");
+    const thread = vm.spawnAt(17).receive(window, "synth", { dom: false });
     vm.clock.seek(31);
     const event = send(window, "synth", { arg: "foo" }); 
     t.undefined(vm.valueOf(thread), "no value before the event");

--- a/tests/vm.html
+++ b/tests/vm.html
@@ -25,7 +25,7 @@ test("Start the clock", async t => {
 
 test("keepAlive (off by default)", async t => {
     const vm = VM().start();
-    const thread = vm.spawn().event(window, "synth").constant("ok");
+    const thread = vm.spawn().receive(window, "synth").constant("ok");
     await notification(vm.clock, "update");
     t.equal(vm.clock.paused, false, "clock still running (scheduler is not idle)");
     window.dispatchEvent(new window.Event("synth"));
@@ -140,56 +140,14 @@ test("Do, undo, redo (effect)", t => {
     );
 });
 
-test("Do, undo, redo (event)", t => {
-    const effects = [];
-    const vm = VM();
-    const thread = vm.spawnAt(17).
-        delay(23).
-        event(window, "A").
-        effect((_, t) => { effects.push(t); }).
-        event(window, "B").
-        effect((_, t) => { effects.push(t); });
-
-    vm.clock.seek(51);
-    window.dispatchEvent(new window.Event("A"));
-    vm.clock.seek(61);
-    t.equal(effects, [34], "event A");
-    vm.clock.seek(47);
-    window.dispatchEvent(new window.Event("A"));
-    vm.clock.seek(71);
-    window.dispatchEvent(new window.Event("B"));
-    vm.clock.seek(72)
-    t.equal(effects, [34, 54], "event B");
-});
-
-test("Event listener cancellation", t => {
-    const effects = [];
-    const vm = VM();
-    const thread = vm.spawn().
-        repeat().
-        spawn(Thread().event(window, "A").effect(() => { effects.push("A"); })).
-        spawn(Thread().event(window, "B").effect(() => { effects.push("B"); })).
-        first().
-        loop();
-
-    vm.clock.seek(17);
-    window.dispatchEvent(new window.Event("A"));
-    vm.clock.seek(19);
-    window.dispatchEvent(new window.Event("A"));
-    vm.clock.seek(23);
-    window.dispatchEvent(new window.Event("B"));
-    vm.clock.seek(31);
-    t.equal(effects, ["A", "A", "B"], "events as they occurred");
-});
-
 test("Do, undo, redo (receive)", t => {
     const effects = [];
     const vm = VM();
     const thread = vm.spawnAt(17).
         delay(23).
-        receive(window, "A").
+        receive(window, "A", { dom: false }).
         effect((_, t) => { effects.push(t); }).
-        receive(window, "B").
+        receive(window, "B", { dom: false }).
         effect((_, t) => { effects.push(t); });
 
     vm.clock.seek(51);
@@ -209,8 +167,8 @@ test("Receive cancellation", t => {
     const vm = VM();
     const thread = vm.spawn().
         repeat().
-        spawn(Thread().receive(window, "A").effect(() => { effects.push("A"); })).
-        spawn(Thread().receive(window, "B").effect(() => { effects.push("B"); })).
+        spawn(Thread().receive(window, "A", { dom: false }).effect(() => { effects.push("A"); })).
+        spawn(Thread().receive(window, "B", { dom: false }).effect(() => { effects.push("B"); })).
         first().
         loop();
 
@@ -220,6 +178,48 @@ test("Receive cancellation", t => {
     send(window, "A");
     vm.clock.seek(23);
     send(window, "B");
+    vm.clock.seek(31);
+    t.equal(effects, ["A", "A", "B"], "events as they occurred");
+});
+
+test("Do, undo, redo (DOM event)", t => {
+    const effects = [];
+    const vm = VM();
+    const thread = vm.spawnAt(17).
+        delay(23).
+        receive(window, "A").
+        effect((_, t) => { effects.push(t); }).
+        receive(window, "B").
+        effect((_, t) => { effects.push(t); });
+
+    vm.clock.seek(51);
+    window.dispatchEvent(new window.Event("A"));
+    vm.clock.seek(61);
+    t.equal(effects, [34], "event A");
+    vm.clock.seek(47);
+    window.dispatchEvent(new window.Event("A"));
+    vm.clock.seek(71);
+    window.dispatchEvent(new window.Event("B"));
+    vm.clock.seek(72)
+    t.equal(effects, [34, 54], "event B");
+});
+
+test("DOM event listener cancellation", t => {
+    const effects = [];
+    const vm = VM();
+    const thread = vm.spawn().
+        repeat().
+        spawn(Thread().receive(window, "A").effect(() => { effects.push("A"); })).
+        spawn(Thread().receive(window, "B").effect(() => { effects.push("B"); })).
+        first().
+        loop();
+
+    vm.clock.seek(17);
+    window.dispatchEvent(new window.Event("A"));
+    vm.clock.seek(19);
+    window.dispatchEvent(new window.Event("A"));
+    vm.clock.seek(23);
+    window.dispatchEvent(new window.Event("B"));
     vm.clock.seek(31);
     t.equal(effects, ["A", "A", "B"], "events as they occurred");
 });


### PR DESCRIPTION
Use a single op for both DOM and internal events, adding a dom option to disambiguate targets that can be both. Also fix a cancellation issue.