### PR TITLE
4F05 Tests should fail when assertions fail

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,12 @@ class Test {
         this.title = title;
         this.f = f;
         this.expectations = 0;
+        this.wrappedAssert = console.assert;
+        console.assert = p => {
+            if (!p) {
+                this.fail("assertion failed");
+            }
+        }
     }
 
     static DefaultMessage = "expectation was met";
@@ -53,6 +59,8 @@ class Test {
         } catch (error) {
             this.report("error running test", `no exception but got: <em>${error.message}</em>`);
             this.passes = false;
+        } finally {
+            console.assert = this.wrappedAssert;
         }
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -29,15 +29,10 @@ class Test {
         this.title = title;
         this.f = f;
         this.expectations = 0;
-        this.wrappedAssert = console.assert;
-        console.assert = p => {
-            if (!p) {
-                this.fail("assertion failed");
-            }
-        }
     }
 
     static DefaultMessage = "expectation was met";
+    static FailDefaultMessage = "unconditional failure";
 
     report(message, expected) {
         if (expected) {
@@ -50,10 +45,24 @@ class Test {
         this.expectations += 1;
     }
 
+    fail(message) {
+        this.passes = false;
+        this.li.innerHTML += ` <span class="ko">ko</span> ${message ?? FailDefaultMessage}`;
+        this.li.scrollIntoView({ block: "end" });
+        this.expectations += 1;
+    }
+
     run(li) {
         this.li = li;
         li.innerHTML = `<span>${this.title}</span>`;
         this.passes = true;
+        this.wrappedAssert = console.assert;
+        console.assert = (...args) => {
+            this.wrappedAssert.apply(console, args);
+            if (!args[0]) {
+                this.fail("assertion failed");
+            }
+        }
         try {
             this.f(this);
         } catch (error) {
@@ -80,10 +89,6 @@ class Test {
 
     equal(x, y, message) {
         this.report(message, !(equal(x, y)) && `${x} and ${y} to be equal`);
-    }
-
-    fail(message) {
-        this.report(message, "not to fail");
     }
 
     pass(message) {

--- a/test/test.js
+++ b/test/test.js
@@ -47,7 +47,7 @@ class Test {
 
     fail(message) {
         this.passes = false;
-        this.li.innerHTML += ` <span class="ko">ko</span> ${message ?? FailDefaultMessage}`;
+        this.li.innerHTML += ` <span class="ko">ko</span> ${message ?? Test.FailDefaultMessage}`;
         this.li.scrollIntoView({ block: "end" });
         this.expectations += 1;
     }
@@ -56,9 +56,9 @@ class Test {
         this.li = li;
         li.innerHTML = `<span>${this.title}</span>`;
         this.passes = true;
-        this.wrappedAssert = console.assert;
+        const assert = console.assert;
         console.assert = (...args) => {
-            this.wrappedAssert.apply(console, args);
+            assert.apply(console, args);
             if (!args[0]) {
                 this.fail("assertion failed");
             }
@@ -69,7 +69,7 @@ class Test {
             this.report("error running test", `no exception but got: <em>${error.message}</em>`);
             this.passes = false;
         } finally {
-            console.assert = this.wrappedAssert;
+            console.assert = assert;
         }
     }
 


### PR DESCRIPTION
Wrap `console.assert` before running a test and report an unmet assert as an error. Unwrap in the finally block. Also improves the output for `Test.fail()`.