### PR TITLE
4E0F Cancel error

### DIFF
--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -327,23 +327,17 @@ export const Last = {
     }
 };
 
-// Delegate to cancel all siblings once the first fiber ends, without changing
-// the fiber value.
-export const Gate = {
-    childFiberDidEnd(_, scheduler) {
+// Delegate to cancel all siblings once the first fiber ends, setting its
+// value as the fiber value (unless `useValue` is set to false).
+export const First = (useValue = true) => ({
+    childFiberDidEnd(child, scheduler) {
         const siblings = [...this.pending];
         this.pending.clear();
         for (const sibling of siblings) {
             sibling.cancel(scheduler);
         }
+        if (useValue) {
+            child.parent.value = child.value;
+        }
     }
-};
-
-// Delegate to get the value of the first child fiber that ends, cancelling
-// all its siblings when it ends.
-export const First = {
-    childFiberDidEnd(child, scheduler) {
-        Gate.childFiberDidEnd.call(this, child, scheduler);
-        child.parent.value = child.value;
-    }
-};
+});

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -5,6 +5,8 @@ let k = 0;
 const AsyncFunction = (async function() {}).constructor;
 const isAsync = f => f.constructor === AsyncFunction;
 
+const Cancelled = Error("cancelled");
+
 export default class Fiber {
     constructor(parent) {
         this.parent = parent;
@@ -32,6 +34,27 @@ export default class Fiber {
 
     get error() {
         return this.result.error;
+    }
+
+    // Cancel a fiber. This sets its error value to Cancelled and resumes
+    // immediately, leaving the fiber a chance to handle cancellation
+    // gracefully. The current value is not overwritten.
+    // FIXME delayed cancellation?
+    // FIXME cancelling the cancellation with either?
+    cancel(scheduler) {
+        console.assert(!this.endTime);
+        this.result.error = Cancelled;
+        if (this.eventDelegate) {
+            // The fiber was waiting for an event
+            const { target, type } = this.eventDelegate;
+            if (target.addEventListener) {
+                target.removeEventListener(type, this.eventDelegate);
+            } else {
+                off(target, type, this.eventDelegate);
+            }
+            delete this.eventDelegate;
+        }
+        scheduler.reschedule(this);
     }
 
     exec(f) {
@@ -257,11 +280,11 @@ export default class Fiber {
     // and resume when the set becomes empty. Do nothing if the child is not
     // pending (e.g., the fiber is not actually joining).
     childDidEnd(fiber, scheduler) {
-        if (!this.joinDelegate?.pending.has(fiber)) {
+        if (!this.joinDelegate?.pending?.has(fiber)) {
             return;
         }
         this.joinDelegate.pending.delete(fiber);
-        this.joinDelegate?.childFiberDidEnd?.call(this.joinDelegate, fiber, scheduler);
+        this.joinDelegate.childFiberDidEnd?.call(this.joinDelegate, fiber, scheduler);
         if (this.joinDelegate.pending.size === 0) {
             delete this.children;
             delete this.joinDelegate;
@@ -303,3 +326,16 @@ export const Last = {
         }
     }
 };
+
+// Delegate to get the value of the first child fiber that ends, cancelling
+// all its siblings when it ends.
+export const First = {
+    childFiberDidEnd(child, scheduler) {
+        const siblings = [...this.pending];
+        this.pending.clear();
+        for (const sibling of siblings) {
+            sibling.cancel(scheduler);
+        }
+        child.parent.value = child.value;
+    }
+}

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -337,7 +337,7 @@ export const Gate = {
             sibling.cancel(scheduler);
         }
     }
-}
+};
 
 // Delegate to get the value of the first child fiber that ends, cancelling
 // all its siblings when it ends.
@@ -346,4 +346,4 @@ export const First = {
         Gate.childFiberDidEnd.call(this, child, scheduler);
         child.parent.value = child.value;
     }
-}
+};

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -298,7 +298,7 @@ export default class Fiber {
         if (this.joinDelegate.pending.size === 0) {
             delete this.children;
             delete this.joinDelegate;
-            scheduler.resume(this);
+            scheduler.resumeDeferred(this);
         }
     }
 }

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -36,16 +36,16 @@ export default class Fiber {
         return this.result.error;
     }
 
-    // Cancel a fiber. This sets its error value to Cancelled and resumes
-    // immediately, leaving the fiber a chance to handle cancellation
-    // gracefully. The current value is not overwritten.
+    // Cancel a fiber and its pending children, if joining. This sets its error
+    // value to Cancelled and resumes immediately, leaving the fiber a chance
+    // to handle cancellation gracefully. The current value is not overwritten.
     // FIXME delayed cancellation?
     // FIXME cancelling the cancellation with either?
     cancel(scheduler) {
         console.assert(!this.endTime);
         this.result.error = Cancelled;
         if (this.eventDelegate) {
-            // The fiber was waiting for an event
+            // The fiber was waiting for an event.
             const { target, type } = this.eventDelegate;
             if (target.addEventListener) {
                 target.removeEventListener(type, this.eventDelegate);
@@ -53,6 +53,15 @@ export default class Fiber {
                 off(target, type, this.eventDelegate);
             }
             delete this.eventDelegate;
+        }
+        if (this.joinDelegate) {
+            // The fiber is joining; cancel the pending children.
+            // Do not cancel children when not joining.
+            const pending = this.joinDelegate.pending;
+            delete this.joinDelegate;
+            for (const fiber of pending) {
+                fiber.cancel(scheduler);
+            }
         }
         scheduler.reschedule(this);
     }
@@ -294,6 +303,7 @@ export default class Fiber {
 }
 
 // Delegate to collect all child fiber values in order.
+// FIXME 4F04 Handle errors when joining
 export const All = {
     fiberWillJoin(fiber) {
         this.values = new Array(fiber.children.length);
@@ -312,6 +322,7 @@ export const All = {
 
 // Delegate to collect all child fiber values in the order in which they
 // finished.
+// FIXME 4F04 Handle errors when joining
 export const Last = {
     fiberWillJoin(fiber) {
         this.values = [];
@@ -329,6 +340,7 @@ export const Last = {
 
 // Delegate to cancel all siblings once the first fiber ends, setting its
 // value as the fiber value (unless `useValue` is set to false).
+// FIXME 4F04 Handle errors when joining
 export const First = (useValue = true) => ({
     childFiberDidEnd(child, scheduler) {
         const siblings = [...this.pending];

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -44,6 +44,7 @@ export default class Fiber {
     cancel(scheduler) {
         console.assert(!this.endTime);
         this.result.error = Cancelled;
+        this.parent?.children?.splice(this.parent?.children?.indexOf(this), 1);
         if (this.eventDelegate) {
             // The fiber was waiting for an event.
             const { target, type } = this.eventDelegate;

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -280,7 +280,7 @@ export default class Fiber {
     // and resume when the set becomes empty. Do nothing if the child is not
     // pending (e.g., the fiber is not actually joining).
     childDidEnd(fiber, scheduler) {
-        if (!this.joinDelegate?.pending?.has(fiber)) {
+        if (!this.joinDelegate?.pending.has(fiber)) {
             return;
         }
         this.joinDelegate.pending.delete(fiber);
@@ -327,15 +327,23 @@ export const Last = {
     }
 };
 
-// Delegate to get the value of the first child fiber that ends, cancelling
-// all its siblings when it ends.
-export const First = {
-    childFiberDidEnd(child, scheduler) {
+// Delegate to cancel all siblings once the first fiber ends, without changing
+// the fiber value.
+export const Gate = {
+    childFiberDidEnd(_, scheduler) {
         const siblings = [...this.pending];
         this.pending.clear();
         for (const sibling of siblings) {
             sibling.cancel(scheduler);
         }
+    }
+}
+
+// Delegate to get the value of the first child fiber that ends, cancelling
+// all its siblings when it ends.
+export const First = {
+    childFiberDidEnd(child, scheduler) {
+        Gate.childFiberDidEnd.call(this, child, scheduler);
         child.parent.value = child.value;
     }
 }

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -1,4 +1,4 @@
-import { on, off } from "./util.js";
+import { remove, on, off } from "./util.js";
 
 let k = 0;
 
@@ -294,6 +294,7 @@ export default class Fiber {
             return;
         }
         this.joinDelegate.pending.delete(fiber);
+        remove(this.children, fiber);
         this.joinDelegate.childFiberDidEnd?.call(this.joinDelegate, fiber, scheduler);
         if (this.joinDelegate.pending.size === 0) {
             delete this.children;

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -41,14 +41,20 @@ export default class Scheduler {
         }
     }
 
+    resumeDeferred(fiber) {
+        console.assert(!this.schedule.has(fiber));
+        this.schedule.set(fiber, this.now);
+        this.resumeQueues[1].push(fiber);
+    }
+
     resume(fiber, t) {
         const now = this.now;
         t = t ?? now;
         console.assert(t >= now);
         console.assert(!this.schedule.has(fiber));
         this.schedule.set(fiber, t);
-        if (t === now && this.resumeQueue) {
-            this.resumeQueue.push(fiber);
+        if (t === now && this.resumeQueues) {
+            this.resumeQueues[0].push(fiber);
             return;
         }
         if (!this.fibersByInstant.has(t)) {
@@ -80,18 +86,19 @@ export default class Scheduler {
                 console.assert(this.schedule.has(fiber));
                 this.schedule.delete(fiber);
                 delete fiber.yielded;
-                this.resumeQueue = [];
+                this.resumeQueues = [[], []];
                 for (const n = fiber.ops.length; !fiber.yielded && fiber.ip < n;) {
                     fiber.ops[fiber.ip++](this);
                 }
                 if (!fiber.yielded) {
                     fiber.ended(this);
                 }
-                Array.prototype.unshift.apply(this.queue, this.resumeQueue);
+                Array.prototype.unshift.apply(this.queue, this.resumeQueues[0]);
+                Array.prototype.push.apply(this.queue, this.resumeQueues[1]);
             }
             this.lastUpdateTime = end;
             delete this.currentTime;
-            delete this.resumeQueue;
+            delete this.resumeQueues;
         }
     }
 }

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -1,4 +1,4 @@
-import { Queue, on, message } from "./util.js";
+import { remove, Queue, on, message } from "./util.js";
 import Fiber from "./fiber.js";
 
 class Clock {
@@ -71,6 +71,7 @@ export default class Scheduler {
             if (t === this.schedule.get(fiber)) {
                 return;
             }
+            remove(this.fibersByInstant.get(this.schedule.get(fiber)), fiber);
             this.schedule.delete(fiber);
         }
         this.resume(fiber, t);

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -79,14 +79,14 @@ export default class Scheduler {
     update(begin, end) {
         while (this.instants.length > 0 && this.instants[0] >= begin && this.instants[0] < end) {
             this.currentTime = this.instants.remove();
-            this.queue = this.fibersByInstant.get(this.currentTime);
+            const queue = this.fibersByInstant.get(this.currentTime);
             this.fibersByInstant.delete(this.currentTime);
-            while (this.queue.length > 0) {
-                const fiber = this.queue.shift();
-                if (!Object.hasOwn(fiber, "ip")) {
+            while (queue.length > 0) {
+                const fiber = queue.shift();
+                if (!(fiber.ip >= 0)) {
                     fiber.reset(this.currentTime);
                 }
-                console.assert(this.schedule.has(fiber));
+                console.assert(this.schedule.get(fiber) === this.currentTime);
                 this.schedule.delete(fiber);
                 delete fiber.yielded;
                 this.resumeQueues = [[], []];
@@ -96,8 +96,8 @@ export default class Scheduler {
                 if (!fiber.yielded) {
                     fiber.ended(this);
                 }
-                Array.prototype.unshift.apply(this.queue, this.resumeQueues[0]);
-                Array.prototype.push.apply(this.queue, this.resumeQueues[1]);
+                Array.prototype.unshift.apply(queue, this.resumeQueues[0]);
+                Array.prototype.push.apply(queue, this.resumeQueues[1]);
             }
             this.lastUpdateTime = end;
             delete this.currentTime;

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -66,11 +66,14 @@ export default class Scheduler {
     }
 
     reschedule(fiber, t) {
-        console.assert(this.schedule.has(fiber));
-        if (t !== this.schedule.get(fiber)) {
+        if (this.schedule.has(fiber)) {
+            t = t ?? this.now;
+            if (t === this.schedule.get(fiber)) {
+                return;
+            }
             this.schedule.delete(fiber);
-            this.resume(fiber, t);
         }
+        this.resume(fiber, t);
     }
 
     update(begin, end) {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -45,6 +45,8 @@ export default class Scheduler {
         const now = this.now;
         t = t ?? now;
         console.assert(t >= now);
+        console.assert(!this.schedule.has(fiber));
+        this.schedule.set(fiber, t);
         if (t === now && this.resumeQueue) {
             this.resumeQueue.push(fiber);
             return;
@@ -54,8 +56,6 @@ export default class Scheduler {
             this.fibersByInstant.set(t, []);
         }
         this.fibersByInstant.get(t).push(fiber);
-        console.assert(!this.schedule.has(fiber));
-        this.schedule.set(fiber, t);
         return fiber;
     }
 
@@ -77,6 +77,8 @@ export default class Scheduler {
                 if (!Object.hasOwn(fiber, "ip")) {
                     fiber.reset(this.currentTime);
                 }
+                console.assert(this.schedule.has(fiber));
+                this.schedule.delete(fiber);
                 delete fiber.yielded;
                 this.resumeQueue = [];
                 for (const n = fiber.ops.length; !fiber.yielded && fiber.ip < n;) {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -53,6 +53,9 @@ export default class Scheduler {
         console.assert(t >= now);
         console.assert(!this.schedule.has(fiber));
         this.schedule.set(fiber, t);
+        if (!(fiber.ip >= 0)) {
+            fiber.reset(t);
+        }
         if (t === now && this.resumeQueues) {
             this.resumeQueues[0].push(fiber);
             return;
@@ -62,7 +65,6 @@ export default class Scheduler {
             this.fibersByInstant.set(t, []);
         }
         this.fibersByInstant.get(t).push(fiber);
-        return fiber;
     }
 
     reschedule(fiber, t) {
@@ -84,9 +86,6 @@ export default class Scheduler {
             this.fibersByInstant.delete(this.currentTime);
             while (queue.length > 0) {
                 const fiber = queue.shift();
-                if (!(fiber.ip >= 0)) {
-                    fiber.reset(this.currentTime);
-                }
                 console.assert(this.schedule.get(fiber) === this.currentTime);
                 this.schedule.delete(fiber);
                 delete fiber.yielded;
@@ -97,8 +96,8 @@ export default class Scheduler {
                 if (!fiber.yielded) {
                     fiber.ended(this);
                 }
+                Array.prototype.unshift.apply(queue, this.resumeQueues[1]);
                 Array.prototype.unshift.apply(queue, this.resumeQueues[0]);
-                Array.prototype.push.apply(queue, this.resumeQueues[1]);
             }
             this.lastUpdateTime = end;
             delete this.currentTime;

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -25,6 +25,7 @@ export default class Scheduler {
         this.lastUpdateTime = this.clock.now;
         this.instants = new Queue();
         this.fibersByInstant = new Map();
+        this.schedule = new Map();
     }
 
     get now() {
@@ -53,7 +54,17 @@ export default class Scheduler {
             this.fibersByInstant.set(t, []);
         }
         this.fibersByInstant.get(t).push(fiber);
+        console.assert(!this.schedule.has(fiber));
+        this.schedule.set(fiber, t);
         return fiber;
+    }
+
+    reschedule(fiber, t) {
+        console.assert(this.schedule.has(fiber));
+        if (t !== this.schedule.get(fiber)) {
+            this.schedule.delete(fiber);
+            this.resume(fiber, t);
+        }
     }
 
     update(begin, end) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,10 @@ export function nop() {
 export const I = x => x;
 export const K = x => () => x;
 
+// Remove the first occurrence of `x` from the array `xs` and return it.
+// `x` must be in `xs`.
+export const remove = (xs, x) => xs.splice(xs.indexOf(x), 1)[0];
+
 // Create a priority queue with a comparison function (min by default).
 export class Queue extends Array {
     constructor(cmp = (a, b) => a - b) {

--- a/test/index.js
+++ b/test/index.js
@@ -823,3 +823,18 @@ test("Fiber.join(First(false)) cancels sibling fibers and does not set its value
     run(fiber);
     t.equal(fiber.value, "ok", "did not change the fiber value");
 });
+
+test("Cancel pending children when joining", t => {
+    const fiber = new Fiber().
+        spawn(fiber => fiber.
+            spawn(fiber => fiber.
+                delay(1111).
+                effect(() => { t.fail("child of cancelled fiber should be cancelled"); })
+            ).
+            join()
+        ).
+        spawn(nop).
+        join(First());
+    run(fiber);
+    t.pass("LGTM");
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 import test from "./test.js";
 import { nop, K, Queue, message, on, off } from "../lib/util.js";
-import Fiber, { All, Last, Gate, First } from "../lib/fiber.js";
+import Fiber, { All, Last, First } from "../lib/fiber.js";
 import Scheduler from "../lib/scheduler.js";
 
 // Utility function to run a fiber synchronously.
@@ -793,7 +793,22 @@ test("Self cancellation", t => {
     t.equal(fiber.error.message, "cancelled", "fiber cancelled itself");
 });
 
-test("Fiber.join(Gate) cancels sibling fibers", t => {
+test("Fiber.join(First()) cancels sibling fibers and sets the fiber value", t => {
+    const fiber = new Fiber().
+        spawn(fiber => fiber.
+            delay(111).
+            either(({ error }, scheduler) => {
+                t.same(error.message, "cancelled", "fiber was cancelled");
+                t.same(scheduler.now, 0, "delay was skipped");
+            })
+        ).
+        spawn(fiber => fiber.exec(K("ok"))).
+        join(First());
+    run(fiber);
+    t.equal(fiber.value, "ok", "first value won");
+});
+
+test("Fiber.join(First(false)) cancels sibling fibers and does not set its value", t => {
     const fiber = new Fiber().
         exec(K("ok")).
         spawn(fiber => fiber.
@@ -804,22 +819,7 @@ test("Fiber.join(Gate) cancels sibling fibers", t => {
             })
         ).
         spawn(fiber => fiber.exec(K("ko"))).
-        join(Gate);
+        join(First(false));
     run(fiber);
     t.equal(fiber.value, "ok", "did not change the fiber value");
-});
-
-test("Fiber.join(First) cancels sibling fibers", t => {
-    const fiber = new Fiber().
-        spawn(fiber => fiber.
-            delay(111).
-            either(({ error }, scheduler) => {
-                t.same(error.message, "cancelled", "fiber was cancelled");
-                t.same(scheduler.now, 0, "delay was skipped");
-            })
-        ).
-        spawn(fiber => fiber.exec(K("ok"))).
-        join(First);
-    run(fiber);
-    t.equal(fiber.value, "ok", "first value won");
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 import test from "./test.js";
-import { nop, K, Queue, message, on, off } from "../lib/util.js";
+import { nop, remove, K, Queue, message, on, off } from "../lib/util.js";
 import Fiber, { All, Last, First } from "../lib/fiber.js";
 import Scheduler from "../lib/scheduler.js";
 
@@ -10,6 +10,12 @@ function run(fiber, scheduler, until = Infinity) {
     scheduler.clock.now = until;
     return scheduler;
 }
+
+test("remove(xs, x)", t => {
+    const xs = [1, 2, 3, 4, 5, 2, 2, 2];
+    t.same(remove(xs, 2), 2, "the removed element is removed");
+    t.equal(xs, [1, 3, 4, 5, 2, 2, 2], "only the first occurrence is removed");
+});
 
 // 4E0A	Priority queue
 

--- a/test/index.js
+++ b/test/index.js
@@ -340,7 +340,7 @@ test("Fiber.event(target, type, delegate?)", t => {
         });
     const scheduler = run(fiber, new Scheduler(), 1);
     window.dispatchEvent(new CustomEvent("hello"));
-    run(fiber, scheduler);
+    scheduler.clock.now = Infinity;
     t.same(fiber.value, -31, "fiber execution resumed after message was sent");
 });
 
@@ -356,7 +356,7 @@ test("Fiber.event(target, type, delegate?)", t => {
         });
     const scheduler = run(fiber, new Scheduler(), 1);
     message(A, "hello");
-    run(fiber, scheduler);
+    scheduler.clock.now = Infinity;
     t.same(fiber.value, -31, "fiber execution resumed after message was sent");
 });
 


### PR DESCRIPTION
Cancel a fiber by setting its `error` and removing it from the pending list; all children are cancelled as well. The main use of cancelling is implementing a `First` join delegate, which ends when the first child joins and cancels the others.