### PR TITLE
4F0D Respawning should reset the fiber

### DIFF
--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -18,6 +18,7 @@ export default class Fiber {
         this.result = { value: this.parent?.value };
         this.ip = 0;
         this.beginTime = t;
+        delete this.endTime;
     }
 
     get value() {
@@ -282,6 +283,7 @@ export default class Fiber {
     // A fiber ended. Its end time is set and its parent (if any) is notified.
     ended(scheduler) {
         console.assert(this.ip === this.ops.length);
+        delete this.ip;
         this.endTime = scheduler.now;
         this.parent?.childDidEnd(this, scheduler);
     }

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -65,7 +65,9 @@ export default class Fiber {
                 fiber.cancel(scheduler);
             }
         }
-        scheduler.reschedule(this);
+        if (this.yielded) {
+            scheduler.reschedule(this);
+        }
     }
 
     exec(f) {

--- a/test/index.js
+++ b/test/index.js
@@ -775,6 +775,21 @@ test("Fiber.join(Last): children and grand-children", t => {
     t.equal(fiber.value, [["A", "B"], "C", ["D", "E"]], "all values are gathered in depth-first order");
 });
 
+test("Repeated spawning", t => {
+    const fiber = new Fiber().
+        exec(K(0)).
+        repeat(fiber => fiber.
+            spawn(fiber => fiber.delay(111)).
+            join().
+            exec(({ value }) => value + 1)
+        );
+    const scheduler = new Scheduler();
+    run(fiber, scheduler, 200);
+    t.same(fiber.value, 1, "first iteration");
+    scheduler.clock.now = 500;
+    t.same(fiber.value, 4, "more iterations");
+});
+
 // 4E0F Cancel error
 
 test("Cancel the current event listener", t => {


### PR DESCRIPTION
Reset the fiber `ip` counter. Also fix an assertion error caused by a fiber cancelling itself; do not resume if the fiber is not yielding.