### PR TITLE
4F0I Either as a container

### DIFF
--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -159,6 +159,8 @@ export default class Fiber {
         return this;
     }
 
+    // Normally fiber execution skips over errors, but either allows handling
+    // them by providing a path for values (f) and a path for errors (g).
     // TODO nesting
     either(f, g) {
         this.ops.push(() => { this.handleError = true; });

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -174,6 +174,7 @@ export default class Fiber {
             f(this);
             this.ops.push(scheduler => {
                 this.ip = end;
+                this.handleError.pop();
             });
             const error = this.ops.length;
             this.ops.push(scheduler => { this.handleValue.push(false); });

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -15,12 +15,14 @@ export default class Fiber {
     }
 
     reset(t) {
-        this.result = { value: this.parent?.value };
-        this.ip = 0;
         this.beginTime = t;
         delete this.endTime;
-        this.handleValue = true;
-        this.handleError = false;
+        this.ip = 0;
+        this.handleValue = this.parent?.handleValue ?? true;
+        this.handleError = this.parent?.handleError ?? false;
+        this.result = this.handleError && this.parent?.error ?
+            { error: this.parent.error } :
+            { value: this.parent?.value };
     }
 
     get value() {
@@ -158,14 +160,32 @@ export default class Fiber {
     }
 
     // TODO nesting
-    either(f) {
-        this.ops.push(() => {
-            this.handleError = true;
-        });
-        f(this);
-        this.ops.push(() => {
-            this.handleError = false;
-        });
+    either(f, g) {
+        this.ops.push(() => { this.handleError = true; });
+        if (g) {
+            this.ops.push(scheduler => {
+                if (this.error) {
+                    this.ip = error;
+                } else {
+                    this.handleError = false;
+                }
+            });
+            f(this);
+            this.ops.push(scheduler => {
+                this.ip = end;
+            });
+            const error = this.ops.length;
+            this.ops.push(scheduler => { this.handleValue = false; });
+            g(this);
+            this.ops.push(scheduler => {
+                this.handleValue = true;
+                this.handleError = false;
+            });
+            const end = this.ops.length;
+        } else {
+            f(this);
+            this.ops.push(() => { this.handleError = false; });
+        }
         return this;
     }
 

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -12,17 +12,17 @@ export default class Fiber {
         this.parent = parent;
         this.id = k++;
         this.ops = [];
-        this.handleErrorStack = [false];
-        this.handleValueStack = [true];
     }
 
     reset(t) {
         this.beginTime = t;
         delete this.endTime;
         this.ip = 0;
-        this.handleValue = this.parent?.handleValue ?? true;
-        this.handleError = this.parent?.handleError ?? false;
-        this.result = this.handleError && this.parent?.error ? { error: this.parent.error } : { value: this.parent?.value };
+        this.handleValue = [this.parent?.handleValue.at(-1) ?? true];
+        this.handleError = [this.parent?.handleError.at(-1) ?? false];
+        this.result = this.handleError.at(-1) && this.parent?.error ?
+            { error: this.parent.error } :
+            { value: this.parent?.value };
     }
 
     get value() {
@@ -42,7 +42,7 @@ export default class Fiber {
     }
 
     get handleResult() {
-        return (this.result.error && this.handleError) || (!this.result.error && this.handleValue);
+        return (this.result.error && this.handleError.at(-1)) || (!this.result.error && this.handleValue.at(-1));
     }
 
     // Cancel a fiber and its pending children, if joining. This sets its error
@@ -162,14 +162,13 @@ export default class Fiber {
     // Normally fiber execution skips over errors, but either allows handling
     // them by providing a path for values (f) and a path for errors (g).
     either(f, g) {
-        this.ops.push(() => { this.handleError = true; });
-        this.handleErrorStack.push(true);
+        this.ops.push(() => { this.handleError.push(true); });
         if (g) {
             this.ops.push(scheduler => {
                 if (this.error) {
                     this.ip = error;
                 } else {
-                    this.handleError = false;
+                    this.handleError.push(false);
                 }
             });
             f(this);
@@ -177,18 +176,16 @@ export default class Fiber {
                 this.ip = end;
             });
             const error = this.ops.length;
-            this.ops.push(scheduler => { this.handleValue = false; });
+            this.ops.push(scheduler => { this.handleValue.push(false); });
             g(this);
             this.ops.push(scheduler => {
-                this.handleValue = true;
-                this.handleError = false;
+                this.handleValue.pop();
+                this.handleError.pop();
             });
             const end = this.ops.length;
         } else {
             f(this);
-            this.handleErrorStack.pop();
-            const handleError = this.handleErrorStack.at(-1);
-            this.ops.push(() => { this.handleError = handleError; });
+            this.ops.push(() => { this.handleError.pop(); });
         }
         return this;
     }

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -19,6 +19,8 @@ export default class Fiber {
         this.ip = 0;
         this.beginTime = t;
         delete this.endTime;
+        this.handleValue = true;
+        this.handleError = false;
     }
 
     get value() {
@@ -35,6 +37,10 @@ export default class Fiber {
 
     get error() {
         return this.result.error;
+    }
+
+    get handleResult() {
+        return (this.result.error && this.handleError) || (!this.result.error && this.handleValue);
     }
 
     // Cancel a fiber and its pending children, if joining. This sets its error
@@ -72,7 +78,7 @@ export default class Fiber {
 
     exec(f) {
         this.ops.push(isAsync(f) ? scheduler => {
-            if (this.result.error) {
+            if (!this.handleResult) {
                 return;
             }
             f(this, scheduler).
@@ -81,7 +87,7 @@ export default class Fiber {
                 finally(() => { scheduler.resume(this); });
             this.yielded = true;
         } : scheduler => {
-            if (this.result.error) {
+            if (!this.handleResult) {
                 return;
             }
             try {
@@ -95,7 +101,7 @@ export default class Fiber {
 
     effect(f) {
         this.ops.push(isAsync(f) ? scheduler => {
-            if (this.result.error) {
+            if (!this.handleResult) {
                 return;
             }
             f(this, scheduler).
@@ -103,7 +109,7 @@ export default class Fiber {
                 finally(() => { scheduler.resume(this); });
             scheduler.yield();
         } : scheduler => {
-            if (this.result.error) {
+            if (!this.handleResult) {
                 return;
             }
             try {
@@ -115,27 +121,10 @@ export default class Fiber {
         return this;
     }
 
-    either(f) {
-        this.ops.push(isAsync(f) ? scheduler => {
-            f(this, scheduler).
-                then(value => { this.value = value; }).
-                catch(error => { this.result.error = error; }).
-                finally(() => { scheduler.resume(this); });
-            this.yielded = true;
-        } : scheduler => {
-            try {
-                this.value = f(this, scheduler);
-            } catch (error) {
-                this.result.error = error;
-            }
-        });
-        return this;
-    }
-
     event(target, type, delegate = {}) {
         this.ops.push(scheduler => {
             console.assert(!this.eventDelegate);
-            if (this.result.error) {
+            if (!this.handleResult) {
                 return;
             }
             // FIXME 4F01 Delegates should be instantiated
@@ -168,9 +157,21 @@ export default class Fiber {
         return this;
     }
 
+    // TODO nesting
+    either(f) {
+        this.ops.push(() => {
+            this.handleError = true;
+        });
+        f(this);
+        this.ops.push(() => {
+            this.handleError = false;
+        });
+        return this;
+    }
+
     repeat(f, delegate = {}) {
         this.ops.push(() => {
-            if (this.error) {
+            if (!this.handleResult) {
                 // Do not set a repeat delegate and skip the cleanup part.
                 this.ip = end + 1;
                 return;
@@ -217,7 +218,7 @@ export default class Fiber {
     // greater than zero. The value of the fiber is not affected by the delay.
     delay(dur) {
         this.ops.push(scheduler => {
-            if (this.error) {
+            if (!this.handleResult) {
                 return;
             }
             if (typeof dur === "function") {
@@ -245,7 +246,7 @@ export default class Fiber {
     spawn(f) {
         const child = new Fiber(this);
         this.ops.push(scheduler => {
-            if (!this.error) {
+            if (this.handleResult) {
                 if (!this.children) {
                     this.children = [];
                 }
@@ -264,7 +265,7 @@ export default class Fiber {
     // or the fiber is failing, do nothing.
     join(delegate = {}) {
         this.ops.push(scheduler => {
-            if (this.error) {
+            if (!this.handleResult) {
                 // FIXME what to do about children?
                 if (this.children?.length > 0) {
                     console.warn(`Not joinining because of error; pending children: ${this.children.size}`);

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -12,6 +12,8 @@ export default class Fiber {
         this.parent = parent;
         this.id = k++;
         this.ops = [];
+        this.handleErrorStack = [false];
+        this.handleValueStack = [true];
     }
 
     reset(t) {
@@ -20,9 +22,7 @@ export default class Fiber {
         this.ip = 0;
         this.handleValue = this.parent?.handleValue ?? true;
         this.handleError = this.parent?.handleError ?? false;
-        this.result = this.handleError && this.parent?.error ?
-            { error: this.parent.error } :
-            { value: this.parent?.value };
+        this.result = this.handleError && this.parent?.error ? { error: this.parent.error } : { value: this.parent?.value };
     }
 
     get value() {
@@ -161,9 +161,9 @@ export default class Fiber {
 
     // Normally fiber execution skips over errors, but either allows handling
     // them by providing a path for values (f) and a path for errors (g).
-    // TODO nesting
     either(f, g) {
         this.ops.push(() => { this.handleError = true; });
+        this.handleErrorStack.push(true);
         if (g) {
             this.ops.push(scheduler => {
                 if (this.error) {
@@ -186,7 +186,9 @@ export default class Fiber {
             const end = this.ops.length;
         } else {
             f(this);
-            this.ops.push(() => { this.handleError = false; });
+            this.handleErrorStack.pop();
+            const handleError = this.handleErrorStack.at(-1);
+            this.ops.push(() => { this.handleError = handleError; });
         }
         return this;
     }

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -160,7 +160,9 @@ export default class Fiber {
     }
 
     // Normally fiber execution skips over errors, but either allows handling
-    // them by providing a path for values (f) and a path for errors (g).
+    // them by providing a path for values (f) and a path for errors (g). When
+    // the second path is omitted, both errors and values are handled; the
+    // fiber has an error if it is failing, and no error otherwise.
     either(f, g) {
         this.ops.push(() => { this.handleError.push(true); });
         if (g) {
@@ -268,13 +270,14 @@ export default class Fiber {
     spawn(f) {
         const child = new Fiber(this);
         this.ops.push(scheduler => {
-            if (this.handleResult) {
-                if (!this.children) {
-                    this.children = [];
-                }
-                this.children.push(child);
-                scheduler.resume(child);
+            if (!this.handleResult) {
+                return;
             }
+            if (!this.children) {
+                this.children = [];
+            }
+            this.children.push(child);
+            scheduler.resume(child);
         });
         if (typeof f === "function") {
             f(child);

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -207,7 +207,7 @@ export default class Fiber {
         });
         const begin = this.ops.length;
         this.ops.push(scheduler => {
-            if (this.error ||
+            if (!this.handleResult ||
                 this.repeatDelegate.repeatShouldEnd?.call(delegate, this.repeatDelegate.count, this, scheduler)) {
                 this.ip = end;
             }

--- a/test/index.js
+++ b/test/index.js
@@ -865,3 +865,29 @@ test("Fiber.either(f) recovers from errors", t => {
     t.true(fiber.value, "error was handled");
     t.undefined(fiber.error, "no more error");
 });
+
+test("Fiber.either(f, g) handles values (with f) or errors (with g)", t => {
+    const fiber = new Fiber().
+        effect(() => { throw Error("AUGH"); }).
+        either(
+            fiber => fiber.effect(() => { t.fail("value branch should not run"); }),
+            fiber => fiber.exec(({ error }) => error.message === "AUGH")
+        );
+    run(fiber);
+    t.same(t.expectations, 0, "value branch did not run");
+    t.true(fiber.value, "error was handled");
+    t.undefined(fiber.error, "no more error");
+});
+
+test("Fiber.either(f, g) handles values (with f) or errors (with g)", t => {
+    const fiber = new Fiber().
+        exec(K(17)).
+        either(
+            fiber => fiber.exec(({ value }) => value * 3),
+            fiber => fiber.effect(() => { t.fail("error branch should not run"); })
+        );
+    run(fiber);
+    t.same(t.expectations, 0, "error branch did not run");
+    t.same(fiber.value, 51, "value branch did run");
+    t.undefined(fiber.error, "no more error");
+});

--- a/test/index.js
+++ b/test/index.js
@@ -902,3 +902,20 @@ test("Normal execution resumes after either", t => {
     t.same(fiber.error.message, "AUGH", "error was actually not handled");
     t.undefined(fiber.value, "the fiber has no value");
 });
+
+test("Nesting either(f)", t => {
+    const fiber = new Fiber().
+        effect(() => { throw Error("AUGH"); }).
+        either(fiber => fiber.
+            effect(({ error }) => { t.same(error.message, "AUGH", "first time to see the error"); }).
+            either(fiber => fiber.
+                effect(({ error }) => { t.same(error.message, "AUGH", "second time to see the error"); })
+            ).
+            effect(({ error }) => { t.same(error.message, "AUGH", "third time to see the error"); })
+        ).
+        effect(() => { t.fail("the error cannot be seen anymore"); });
+    run(fiber);
+    t.same(t.expectations, 3, "error was seen at every step");
+    t.same(fiber.error.message, "AUGH", "error was not handled");
+    t.undefined(fiber.value, "the fiber has no value");
+});

--- a/test/index.js
+++ b/test/index.js
@@ -141,7 +141,7 @@ test("message(from, type) sends a message; on(from, type, handler) listens to me
         A.handled = true;
     });
     t.undefined(message(A, "hello"), "return nothing");
-    t.same(A.handled, true, "message was handled");
+    t.true(A.handled, "message was handled");
 });
 
 test("message(from, type, message) adds additional arguments", t => {
@@ -274,7 +274,7 @@ test("Fiber.effect(f)", t => {
             return 17;
         });
     run(fiber, scheduler);
-    t.same(ran, true, "effect ran");
+    t.true(ran, "effect ran");
     t.same(fiber.value, 19, "but the fiber value is unchanged");
 });
 
@@ -295,42 +295,6 @@ test("Fiber.effect(f) does not run after an error", t => {
     run(fiber);
     t.same(ran, false, "the effect did not run");
     t.same(fiber.error.message, "AUGH", "the error was caught");
-});
-
-test("Fiber.either(f)", t => {
-    const scheduler = new Scheduler();
-    const fiber = new Fiber().
-        either(function(...args) {
-            t.same(args.length, 2, "f is called with two arguments");
-            t.same(args[0], fiber, "f is called with `fiber` as the first argument");
-            t.same(args[1], scheduler, "f is called with `scheduler` as the second argument");
-            return 23;
-        });
-    run(fiber, scheduler);
-    t.same(fiber.value, 23, "the fiber has a value");
-    t.undefined(fiber.error, "the fiber has no error");
-});
-
-test("Fiber.either(f) catches error", t => {
-    const fiber = new Fiber().
-        exec(K(17)).
-        either(() => { throw Error("AUGH"); });
-    run(fiber);
-    t.undefined(fiber.value, "the fiber has no value");
-    t.same(fiber.error.message, "AUGH", "the error was caught");
-});
-
-test("Fiber.either(f) recovers from errors", t => {
-    const fiber = new Fiber().
-        effect(() => { throw Error("AUGH"); }).
-        either(fiber => {
-            if (fiber.error) {
-                return 29;
-            }
-        });
-    run(fiber);
-    t.same(fiber.value, 29, "the fiber has a value");
-    t.undefined(fiber.error, "the error was cleared");
 });
 
 // 4D0D Event
@@ -374,7 +338,7 @@ test("Event delegate: eventShouldBeIgnored(event, fiber, scheduler)", t => {
             if (this.count === 0) {
                 t.same(args.length, 3, "called with three arguments");
                 t.same(this, delegate, "`this` is the delegate object");
-                t.same(event.target === window && event.type === "hello", true, "`event` is the first argument");
+                t.true(event.target === window && event.type === "hello", "`event` is the first argument");
                 t.same(args[1], fiber, "`fiber` is the second argument");
                 t.same(args[2], scheduler, "`scheduler` is the third argument");
             }
@@ -407,7 +371,7 @@ test("Event delegate: eventShouldBeIgnored(event, fiber, scheduler)", t => {
             if (this.count === 0) {
                 t.same(args.length, 3, "called with three arguments");
                 t.same(this, delegate, "`this` is the delegate object");
-                t.same(event.from === A && event.type === "hello", true, "`event` is the first argument");
+                t.true(event.from === A && event.type === "hello", "`event` is the first argument");
                 t.same(args[1], fiber, "`fiber` is the second argument");
                 t.same(args[2], scheduler, "`scheduler` is the third argument");
             }
@@ -439,7 +403,7 @@ test("Event delegate: eventWasHandled(event, fiber, scheduler)", t => {
             const event = args[0];
             t.same(args.length, 3, "called with three arguments");
             t.same(this, delegate, "`this` is the delegate object");
-            t.same(event.target === window && event.type === "hello", true, "`event` is the first argument");
+            t.true(event.target === window && event.type === "hello", "`event` is the first argument");
             t.same(args[1], fiber, "`fiber` is the second argument");
             t.same(args[2], scheduler, "`scheduler` is the third argument");
             fiber.value = event.detail.whom;
@@ -459,7 +423,7 @@ test("Event delegate: eventWasHandled(event, fiber, scheduler)", t => {
             const event = args[0];
             t.same(args.length, 3, "called with three arguments");
             t.same(this, delegate, "`this` is the delegate object");
-            t.same(event.from === A && event.type === "hello", true, "`event` is the first argument");
+            t.true(event.from === A && event.type === "hello", "`event` is the first argument");
             t.same(args[1], fiber, "`fiber` is the second argument");
             t.same(args[2], scheduler, "`scheduler` is the third argument");
             fiber.value = event.whom;
@@ -513,7 +477,7 @@ test("Fiber.repeat does not begin if the fiber is failing", t => {
     const fiber = new Fiber().
         effect(() => { throw Error("AUGH"); }).
         repeat(fiber => fiber.effect(() => { t.fail("repeat should not begin"); })).
-        either(({ error }) => error.message === "AUGH");
+        either(fiber => fiber.exec(({ error }) => error.message === "AUGH"));
     run(fiber);
     t.same(fiber.value, true, "repeat did not begin");
 });
@@ -569,7 +533,7 @@ test("Fiber delay fails if `dur` is a function that fails", t => {
     const scheduler = new Scheduler();
     const fiber = new Fiber().
         delay(() => { throw Error("AUGH"); }).
-        either((_, scheduler) => scheduler.currentTime);
+        either(fiber => fiber.exec((_, scheduler) => scheduler.currentTime));
     run(fiber);
     t.same(fiber.value, 0, "no delay");
 });
@@ -578,7 +542,7 @@ test("Fiber.delay is skipped when the fiber is failing", t => {
     const fiber = new Fiber().
         exec(() => { throw "AUGH"; }).
         delay(999).
-        either((_, scheduler) => scheduler.currentTime);
+        either(fiber => fiber.exec((_, scheduler) => scheduler.currentTime));
     run(fiber);
     t.same(fiber.value, 0, "no delay");
 });
@@ -818,10 +782,12 @@ test("Fiber.join(First()) cancels sibling fibers and sets the fiber value", t =>
     const fiber = new Fiber().
         spawn(fiber => fiber.
             delay(111).
-            either(({ error }, scheduler) => {
-                t.same(error.message, "cancelled", "fiber was cancelled");
-                t.same(scheduler.now, 0, "delay was skipped");
-            })
+            either(fiber => fiber.
+                effect(({ error }, scheduler) => {
+                    t.same(error.message, "cancelled", "fiber was cancelled");
+                    t.same(scheduler.now, 0, "delay was skipped");
+                })
+            )
         ).
         spawn(fiber => fiber.exec(K("ok"))).
         join(First());
@@ -833,27 +799,13 @@ test("Fiber.join(First()) cancels sibling fibers and sets the fiber value", t =>
     const fiber = new Fiber().
         spawn(fiber => fiber.exec(K("ok"))).
         spawn(fiber => fiber.
-            either(({ error }, scheduler) => { t.same(error.message, "cancelled", "fiber was cancelled"); })
+            either(fiber => fiber.
+                effect(({ error }, scheduler) => { t.same(error.message, "cancelled", "fiber was cancelled"); })
+            )
         ).
         join(First());
     run(fiber);
     t.equal(fiber.value, "ok", "first value won (sync)");
-});
-
-test("Fiber.join(First(false)) cancels sibling fibers and does not set its value", t => {
-    const fiber = new Fiber().
-        exec(K("ok")).
-        spawn(fiber => fiber.
-            delay(111).
-            either(({ error }, scheduler) => {
-                t.same(error.message, "cancelled", "fiber was cancelled");
-                t.same(scheduler.now, 0, "delay was skipped");
-            })
-        ).
-        spawn(fiber => fiber.exec(K("ko"))).
-        join(First(false));
-    run(fiber);
-    t.equal(fiber.value, "ok", "did not change the fiber value");
 });
 
 test("Cancel pending children when joining", t => {
@@ -871,6 +823,24 @@ test("Cancel pending children when joining", t => {
     t.pass();
 });
 
+test("Fiber.join(First(false)) cancels sibling fibers and does not set its value", t => {
+    const fiber = new Fiber().
+        exec(K("ok")).
+        spawn(fiber => fiber.
+            delay(111).
+            either(fiber => fiber.
+                effect(({ error }, scheduler) => {
+                    t.same(error.message, "cancelled", "fiber was cancelled");
+                    t.same(scheduler.now, 0, "delay was skipped");
+                })
+            )
+        ).
+        spawn(fiber => fiber.exec(K("ko"))).
+        join(First(false));
+    run(fiber);
+    t.equal(fiber.value, "ok", "did not change the fiber value");
+});
+
 test("Do not cancel child when not joining", t => {
     const fiber = new Fiber().
         spawn(fiber => fiber.
@@ -883,4 +853,15 @@ test("Do not cancel child when not joining", t => {
         join(First());
     run(fiber);
     t.atleast(t.expectations, 1, "child fiber kept running");
+});
+
+// 4E0G Retry
+
+test("Fiber.either(f) recovers from errors", t => {
+    const fiber = new Fiber().
+        effect(() => { throw Error("AUGH"); }).
+        either(fiber => fiber.exec(({ error }) => error.message === "AUGH"));
+    run(fiber);
+    t.true(fiber.value, "error was handled");
+    t.undefined(fiber.error, "no more error");
 });

--- a/test/index.js
+++ b/test/index.js
@@ -892,6 +892,19 @@ test("Fiber.either(f, g) handles values (with f) or errors (with g)", t => {
     t.undefined(fiber.error, "no more error");
 });
 
+test("Error within value of branch of either", t => {
+    const fiber = new Fiber().
+        either(
+            fiber => fiber.
+                effect(() => { throw Error("AUGH"); }).
+                effect(() => { t.fail("error should not be handled here"); }),
+            nop
+        ).
+        either(fiber => fiber.exec(K("ok")));
+    run(fiber);
+    t.same(fiber.value, "ok", "error was handled in second either");
+});
+
 test("Normal execution resumes after either", t => {
     const fiber = new Fiber().
         effect(() => { throw Error("AUGH"); }).

--- a/test/index.js
+++ b/test/index.js
@@ -891,3 +891,14 @@ test("Fiber.either(f, g) handles values (with f) or errors (with g)", t => {
     t.same(fiber.value, 51, "value branch did run");
     t.undefined(fiber.error, "no more error");
 });
+
+test("Normal execution resumes after either", t => {
+    const fiber = new Fiber().
+        effect(() => { throw Error("AUGH"); }).
+        either(fiber => fiber.effect(({ error }) => { t.same(error.message, "AUGH", "error is being handled"); })).
+        exec(K(23));
+    run(fiber);
+    t.atleast(t.expectations, 1, "was error handled?");
+    t.same(fiber.error.message, "AUGH", "error was actually not handled");
+    t.undefined(fiber.value, "the fiber has no value");
+});

--- a/test/test.js
+++ b/test/test.js
@@ -119,6 +119,10 @@ class Test {
         this.li.classList.add("todo");
     }
 
+    true(x, message) {
+        this.report(message, x !== true, `${x} to be true`);
+    }
+
     undefined(x, message) {
         this.report(message, !(x === void 0) && `${x} to be undefined`);
     }

--- a/test/test.js
+++ b/test/test.js
@@ -69,6 +69,9 @@ class Test {
             this.report("error running test", `no exception but got: <em>${error.message}</em>`);
             this.passes = false;
         } finally {
+            if (this.expectations === 0) {
+                this.fail("no expectations in test");
+            }
             console.assert = assert;
         }
     }


### PR DESCRIPTION
Either is a container allowing its contents to handle errors as well as values. It can either handle both in the same path (the `error` property of the fiber will be set if it is failing; the `value` property should be accessed otherwise), or on two different paths (the first path will only process values, as usual, while the second path will only process errors).