### PR TITLE
4G08 Tests should fail on unexpected warnings

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1066,8 +1066,8 @@ test("Fiber.delay(dur) has no effect with a negative offset ", t => {
     run(fiber);
 });
 
-// FIXME 4G08 Tests should fail on unexpected warnings
 test("Fiber.delay(dur) has no effect when the duration cannot be parsed", t => {
+    t.expectsWarning = true;
     const fiber = new Fiber().
         delay("for a while").
         effect((_, scheduler) => {

--- a/test/test.js
+++ b/test/test.js
@@ -62,7 +62,17 @@ class Test {
             if (!args[0]) {
                 this.fail("assertion failed");
             }
-        }
+        };
+        const warn = console.warn;
+        this.warnings = 0;
+        console.warn = (...args) => {
+            warn.apply(console, args);
+            if (!this.expectsWarning) {
+                this.fail("unexpected warning");
+            } else {
+                this.warnings += 1;
+            }
+        };
         try {
             this.f(this);
         } catch (error) {
@@ -72,7 +82,11 @@ class Test {
             if (this.expectations === 0) {
                 this.fail("no expectations in test");
             }
+            if (this.expectsWarning && this.warnings === 0) {
+                this.fail("no warnings during test");
+            }
             console.assert = assert;
+            console.warn = warn;
         }
     }
 


### PR DESCRIPTION
Fail when a warning is issued. Set `t.expectsWarning` to true to catch expected warnings.