### PR TITLE
4G0G Dynamic delay duration

### DIFF
--- a/examples/timer.html
+++ b/examples/timer.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" href="style.css"/>
         <script type="module">
 import Scheduler from "../lib/scheduler.js";
-import { First } from "../lib/fiber.js";
+import Fiber, { First } from "../lib/fiber.js";
 import { K } from "../lib/util.js";
 
 const [timer, elapsed] = document.querySelectorAll("span");
@@ -19,9 +19,13 @@ Scheduler.run().
     spawn(fiber => fiber.
         repeat(fiber => fiber.
             exec(() => range.value).
-            effect(({ value }) => {
+            effect(({ value }, scheduler) => {
                 timer.textContent = `${value}s`;
                 progress.max = value * 1000;
+                const f = Fiber.byName.get("delay");
+                if (scheduler.hasDelay(f)) {
+                    scheduler.updateDelay(f, progress.max);
+                }
             }).
             event(range, "input")
         )
@@ -32,19 +36,20 @@ Scheduler.run().
             effect(() => {
                 button.disabled = true;
             }).
+            spawn(fiber => fiber.name("delay").delay(() => progress.max)).
             spawn(fiber => fiber.
-                exec(K(0)).
                 repeat(fiber => fiber.
-                    effect(({ value }) => {
-                        progress.value = value;
-                        elapsed.textContent = `${(value / 1000).toFixed(1)}s`;
-                    }).
-                    delay(100).
-                    exec((fiber, scheduler) => scheduler.now - fiber.beginTime),
-                    { repeatShouldEnd: (_, { value }) => value > progress.max }
+                    delay(200).
+                    either(fiber => fiber.
+                        effect((fiber, scheduler) => {
+                            const d = scheduler.now - fiber.beginTime;
+                            progress.value = d;
+                            elapsed.textContent = `${(d / 1000).toFixed(1)}s`;
+                        })
+                    )
                 )
             ).
-            join().
+            join(First()).
             delay(1000).
             effect(() => {
                 button.disabled = false;

--- a/examples/timer.html
+++ b/examples/timer.html
@@ -39,7 +39,7 @@ Scheduler.run().
             spawn(fiber => fiber.name("delay").delay(() => progress.max)).
             spawn(fiber => fiber.
                 repeat(fiber => fiber.
-                    delay(200).
+                    delay(100).
                     either(fiber => fiber.
                         effect((fiber, scheduler) => {
                             const d = scheduler.now - fiber.beginTime;

--- a/examples/timer.html
+++ b/examples/timer.html
@@ -81,9 +81,6 @@ Scheduler.run().
             <span class="todo">TODO</span> Analog timer (with second hand).
         </p>
         <p>
-            <span class="todo">TODO</span> Use an actual delay instead of checking the elapsed time in the repeat.
-        </p>
-        <p>
             This example is inspired by <a href="https://eugenkiss.github.io/7guis/tasks/#timer">7GUIs: A GUI Programming
             Benchmark</a>.
         </p>

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -14,6 +14,15 @@ export default class Fiber {
         this.ops = [];
     }
 
+    static byName = new Map();
+
+    name(name) {
+        console.assert(!Fiber.byName.has(this));
+        Fiber.byName.set(name, this);
+        this.id += ":" + name;
+        return this;
+    }
+
     reset(t) {
         this.beginTime = t;
         delete this.endTime;
@@ -259,8 +268,7 @@ export default class Fiber {
                 dur = parseOffsetValue(dur);
             }
             if (typeof dur === "number" && dur > 0) {
-                this.yielded = true;
-                scheduler.resume(this, scheduler.now + dur);
+                scheduler.delay(this, dur);
             }
         });
         return this;

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -256,19 +256,20 @@ export default class Fiber {
             if (!this.handleResult) {
                 return;
             }
+            let effectiveDur = dur;
             if (typeof dur === "function") {
                 try {
-                    dur = dur(this, scheduler);
+                    effectiveDur = dur(this, scheduler);
                 } catch (error) {
                     this.result.error = error;
                     return;
                 }
             }
-            if (typeof dur === "string") {
-                dur = parseOffsetValue(dur);
+            if (typeof effectiveDur === "string") {
+                effectiveDur = parseOffsetValue(effectiveDur);
             }
-            if (typeof dur === "number" && dur > 0) {
-                scheduler.delay(this, dur);
+            if (typeof effectiveDur === "number" && effectiveDur > 0) {
+                scheduler.delay(this, effectiveDur);
             }
         });
         return this;

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -10,6 +10,7 @@ export default class Scheduler {
         this.instants = new Queue();
         this.fibersByInstant = new Map();
         this.schedule = new Map();
+        this.delays = new Map();
     }
 
     static run() {
@@ -63,6 +64,22 @@ export default class Scheduler {
         this.resume(fiber, t);
     }
 
+    delay(fiber, dur) {
+        const begin = this.now;
+        const end = begin + dur;
+        this.delays.set(fiber, begin);
+        fiber.yielded = true;
+        this.resume(fiber, end);
+    }
+
+    updateDelay(fiber, dur) {
+        console.assert(this.delays.has(fiber));
+        const begin = this.delays.get(fiber);
+        this.delays.delete(fiber);
+        console.assert(dur > 0);
+        this.reschedule(fiber, Math.max(begin + dur, this.now));
+    }
+
     update(begin, end) {
         console.assert(this.instants.length === 0 || this.instants[0] >= begin);
         while (this.instants.length > 0 && this.instants[0] >= begin && this.instants[0] < end) {
@@ -73,6 +90,7 @@ export default class Scheduler {
                 const fiber = queue.shift();
                 console.assert(this.schedule.get(fiber) === this.currentTime);
                 this.schedule.delete(fiber);
+                this.delays.delete(fiber);
                 delete fiber.yielded;
                 this.resumeQueues = [[], []];
                 for (const n = fiber.ops.length; !fiber.yielded && fiber.ip < n;) {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -72,10 +72,13 @@ export default class Scheduler {
         this.resume(fiber, end);
     }
 
+    hasDelay(fiber) {
+        return this.delays.has(fiber);
+    }
+
     updateDelay(fiber, dur) {
         console.assert(this.delays.has(fiber));
         const begin = this.delays.get(fiber);
-        this.delays.delete(fiber);
         console.assert(dur > 0);
         this.reschedule(fiber, Math.max(begin + dur, this.now));
     }

--- a/test/index.js
+++ b/test/index.js
@@ -554,6 +554,16 @@ test("Fiber.delay is skipped when the fiber is failing", t => {
     t.same(fiber.value, 0, "no delay");
 });
 
+test("Fiber.delay(dur): dur function may be evaluated several times", t => {
+    const delays = [111, 222, 333];
+    const fiber = new Fiber().
+        repeat(fiber => fiber.delay(() => delays.shift()), {
+            repeatShouldEnd: () => delays.length === 0
+        });
+    run(fiber);
+    t.same(fiber.endTime, 666, "three different delays");
+});
+
 // 4E0C Spawn
 
 test("Fiber.spawn() creates a new fiber immediately", t => {

--- a/test/index.js
+++ b/test/index.js
@@ -230,6 +230,13 @@ test("Fiber with no op", t => {
     t.same(fiber.endTime, 0, "ended at t=0");
 });
 
+test("Fiber.name(name)", t => {
+    const fiber = new Fiber();
+    t.same(fiber.name("foo"), fiber, "returns the fiber");
+    t.match(fiber.id, /\bfoo\b/, `is part of the fiber id (${fiber.id})`);
+    t.same(Fiber.byName.get("foo"), fiber, "allows finding the fiber by its name");
+});
+
 test("Fiber.exec(f)", t => {
     const scheduler = new Scheduler();
     const fiber = new Fiber().exec(function(...args) {
@@ -1074,4 +1081,39 @@ test("Fiber.delay(dur) has no effect when the duration cannot be parsed", t => {
             t.same(scheduler.now, 0, "no delay");
         });
     run(fiber);
+});
+
+// 4G0G Dynamic delay duration
+
+test("Scheduler.updateDelay(fiber) can set a new (longer) duration for an ongoing delay", t => {
+    const fiber = new Fiber().
+        delay(777).
+        effect((_, scheduler) => {
+            t.same(scheduler.now, 999, "delay was lenghtened");
+        });
+    const scheduler = run(fiber, new Scheduler(), 666);
+    scheduler.updateDelay(fiber, 999);
+    scheduler.clock.now = Infinity;
+});
+
+test("Scheduler.updateDelay(fiber) can set a new (shorter) duration for an ongoing delay", t => {
+    const fiber = new Fiber().
+        delay(777).
+        effect((_, scheduler) => {
+            t.same(scheduler.now, 444, "delay was shortened");
+        });
+    const scheduler = run(fiber, new Scheduler(), 200);
+    scheduler.updateDelay(fiber, 444);
+    scheduler.clock.now = Infinity;
+});
+
+test("Scheduler.updateDelay(fiber) can set a new (shorter) duration for an ongoing delay", t => {
+    const fiber = new Fiber().
+        delay(777).
+        effect((_, scheduler) => {
+            t.same(scheduler.now, 200, "delay ended now");
+        });
+    const scheduler = run(fiber, new Scheduler(), 200);
+    scheduler.updateDelay(fiber, 111);
+    scheduler.clock.now = Infinity;
 });

--- a/test/test.js
+++ b/test/test.js
@@ -108,6 +108,10 @@ class Test {
         this.report(message, !(equal(x, y)) && `${x} and ${y} to be equal`);
     }
 
+    match(x, pattern, message) {
+        this.report(message, !pattern.test(x) && `${x} to match /${pattern}/`);
+    }
+
     pass(message) {
         this.report(message);
     }


### PR DESCRIPTION
Allow updating the current delay for a fiber from the scheduler. In order to be able to access the fiber, also give a way to name fibers so that they can be retrieved by their unique name using the `Fiber.byName` map. Update the timer example to avoid the ugly loop condition check.