### PR TITLE
4G0N Show error messages in fibers

### DIFF
--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -51,6 +51,12 @@ export default class Fiber {
         return (this.result.error && this.handleError.at(-1)) || (!this.result.error && this.handleValue.at(-1));
     }
 
+    // Set the error field of the result and report it to the console.
+    errorWithMessage(error) {
+        this.result.error = error;
+        console.error(error.message ?? error);
+    }
+
     // Cancel a fiber and its pending children, if joining. This sets its error
     // value to Cancelled and resumes immediately, leaving the fiber a chance
     // to handle cancellation gracefully. The current value is not overwritten.
@@ -91,7 +97,7 @@ export default class Fiber {
             }
             f(this, scheduler).
                 then(value => { this.value = value; }).
-                catch(error => { this.result.error = error; }).
+                catch(error => { this.errorWithMessage(error); }).
                 finally(() => { scheduler.resume(this); });
             this.yielded = true;
         } : scheduler => {
@@ -101,7 +107,7 @@ export default class Fiber {
             try {
                 this.value = f(this, scheduler);
             } catch (error) {
-                this.result.error = error;
+                this.errorWithMessage(error);
             }
         });
         return this;
@@ -113,7 +119,7 @@ export default class Fiber {
                 return;
             }
             f(this, scheduler).
-                catch(error => { this.result.error = error; }).
+                catch(error => { this.errorWithMessage(error); }).
                 finally(() => { scheduler.resume(this); });
             scheduler.yield();
         } : scheduler => {
@@ -123,7 +129,7 @@ export default class Fiber {
             try {
                 f(this, scheduler);
             } catch (error) {
-                this.result.error = error;
+                this.errorWithMessage(error);
             }
         });
         return this;
@@ -225,7 +231,7 @@ export default class Fiber {
         f(this);
         this.ops.push(scheduler => {
             if (!this.repeatDelegate.repeatShouldEnd && scheduler.now === this.repeatDelegate.iterationTime) {
-                this.result.error = Error("Zero duration repeat");
+                this.errorWithMessage(Error("Zero duration repeat"));
             } else {
                 this.repeatDelegate.count += 1;
                 this.ip = begin;
@@ -301,7 +307,7 @@ export default class Fiber {
             try {
                 dur = dur(this, scheduler);
             } catch (error) {
-                this.result.error = error;
+                this.errorWithMessage(error);
                 return;
             }
         }

--- a/test/index.js
+++ b/test/index.js
@@ -251,6 +251,7 @@ test("Fiber.exec(f)", t => {
 });
 
 test("Fiber.exec(f) catches errors", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         exec(K(17)).
         exec(() => { throw Error("AUGH"); });
@@ -260,6 +261,7 @@ test("Fiber.exec(f) catches errors", t => {
 });
 
 test("Fiber.exec(f) does not run after an error", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         exec(() => { throw Error("AUGH"); }).
         effect(K(17));
@@ -286,6 +288,7 @@ test("Fiber.effect(f)", t => {
 });
 
 test("Fiber.effect(f) catches errors", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         exec(K(17)).
         effect(() => { throw Error("AUGH"); });
@@ -295,6 +298,7 @@ test("Fiber.effect(f) catches errors", t => {
 });
 
 test("Fiber.effect(f) does not run after an error", t => {
+    t.expectsError = true;
     let ran = false;
     const fiber = new Fiber().
         exec(() => { throw Error("AUGH"); }).
@@ -472,6 +476,7 @@ test("Fiber.repeat(f, delegate)", t => {
 });
 
 test("Fiber.repeat fails if it has zero duration and no delegate", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         exec(K(19)).
         repeat(fiber => fiber.exec(({ value }) => value + 1));
@@ -481,6 +486,7 @@ test("Fiber.repeat fails if it has zero duration and no delegate", t => {
 });
 
 test("Fiber.repeat does not begin if the fiber is failing", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         effect(() => { throw Error("AUGH"); }).
         repeat(fiber => fiber.effect(() => { t.fail("repeat should not begin"); })).
@@ -490,6 +496,7 @@ test("Fiber.repeat does not begin if the fiber is failing", t => {
 });
 
 test("Fiber.repeat does not continue when the fiber is failing", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         repeat(fiber => fiber.effect(() => { throw Error("AUGH"); }), {
             repeatShouldEnd: count => {
@@ -537,6 +544,7 @@ test("Fiber.delay(dur)", t => {
 });
 
 test("Fiber delay fails if `dur` is a function that fails", t => {
+    t.expectsError = true;
     const scheduler = new Scheduler();
     const fiber = new Fiber().
         delay(() => { throw Error("AUGH"); }).
@@ -546,6 +554,7 @@ test("Fiber delay fails if `dur` is a function that fails", t => {
 });
 
 test("Fiber.delay is skipped when the fiber is failing", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         exec(() => { throw "AUGH"; }).
         delay(999).
@@ -635,6 +644,7 @@ test("Fiber.spawn: children and grand-children (yielding)", t => {
 });
 
 test("Fiber.spawn: child does not begin when the parent is failing", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         effect(() => { throw Error("AUGH"); }).
         spawn(fiber => fiber.
@@ -875,6 +885,7 @@ test("Do not cancel child when not joining", t => {
 // 4E0G Retry
 
 test("Fiber.either(f) recovers from errors", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         effect(() => { throw Error("AUGH"); }).
         either(fiber => fiber.exec(({ error }) => error.message === "AUGH"));
@@ -884,6 +895,7 @@ test("Fiber.either(f) recovers from errors", t => {
 });
 
 test("Fiber.either(f, g) handles values (with f) or errors (with g)", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         effect(() => { throw Error("AUGH"); }).
         either(
@@ -910,6 +922,7 @@ test("Fiber.either(f, g) handles values (with f) or errors (with g)", t => {
 });
 
 test("Error within value of branch of either", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         either(
             fiber => fiber.
@@ -923,6 +936,7 @@ test("Error within value of branch of either", t => {
 });
 
 test("Normal execution resumes after either", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         effect(() => { throw Error("AUGH"); }).
         either(fiber => fiber.effect(({ error }) => { t.same(error.message, "AUGH", "error is being handled"); })).
@@ -934,6 +948,7 @@ test("Normal execution resumes after either", t => {
 });
 
 test("Either and delay", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         effect(() => { throw Error("AUGH"); }).
         delay(2222).
@@ -946,6 +961,7 @@ test("Either and delay", t => {
 });
 
 test("Either and event", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         effect(() => { throw Error("AUGH"); }).
         either(fiber => fiber.event(window, "hello", {
@@ -960,6 +976,7 @@ test("Either and event", t => {
 });
 
 test("Either and repeat", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         effect(() => { throw Error("AUGH"); }).
         either(fiber => fiber.
@@ -976,6 +993,7 @@ test("Either and repeat", t => {
 });
 
 test("Either and spawn", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         exec(K(17)).
         effect(() => { throw Error("AUGH"); }).
@@ -992,6 +1010,7 @@ test("Either and spawn", t => {
 });
 
 test("Nesting either(f)", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         effect(() => { throw Error("AUGH"); }).
         either(fiber => fiber.
@@ -1009,6 +1028,7 @@ test("Nesting either(f)", t => {
 });
 
 test("Nesting either(f, g)", t => {
+    t.expectsError = true;
     const fiber = new Fiber().
         exec(K("...")).
         either(fiber => fiber.

--- a/test/test.js
+++ b/test/test.js
@@ -63,6 +63,16 @@ class Test {
                 this.fail("assertion failed");
             }
         };
+        const error = console.error;
+        this.errors = 0;
+        console.error = (...args) => {
+            error.apply(console, args);
+            if (!this.expectsError) {
+                this.fail("unexpected error");
+            } else {
+                this.errors += 1;
+            }
+        };
         const warn = console.warn;
         this.warnings = 0;
         console.warn = (...args) => {
@@ -85,8 +95,12 @@ class Test {
             if (this.expectsWarning && this.warnings === 0) {
                 this.fail("no warnings during test");
             }
+            if (this.expectsError && this.errors === 0) {
+                this.fail("no errors during test");
+            }
             console.assert = assert;
             console.warn = warn;
+            console.error = error;
         }
     }
 


### PR DESCRIPTION
Errors that are caught in exec, effect, &c. are also reported to the console. Tests now catch unexpected errors like they do warnings.