### PR TITLE
4C08 Fiber rate

### DIFF
--- a/examples/timer.html
+++ b/examples/timer.html
@@ -21,7 +21,7 @@ Scheduler.run().
             effect(({ value }, scheduler) => {
                 timer.textContent = `${value}s`;
                 progress.max = value * 1000;
-                const f = Fiber.byName.get("timer");
+                const f = Fiber.byName("timer");
                 scheduler.updateDelayForFiber(f, progress.max);
             }).
             event(range, "input")

--- a/examples/timer.html
+++ b/examples/timer.html
@@ -22,9 +22,7 @@ Scheduler.run().
                 timer.textContent = `${value}s`;
                 progress.max = value * 1000;
                 const f = Fiber.byName.get("timer");
-                if (scheduler.hasDelay(f)) {
-                    scheduler.updateDelay(f, progress.max);
-                }
+                scheduler.updateDelayForFiber(f, progress.max);
             }).
             event(range, "input")
         )

--- a/examples/turtle.html
+++ b/examples/turtle.html
@@ -120,6 +120,10 @@ turtle.
         successive instructions are added to the fiber, ensuring the correct scheduling of their execution. This also
         allows additional effects like <code>wait</code>ing, which is simply a call to the fiber <code>delay</code>
         instruction.</p>
+        <p>The speed of the turtle can be controlled either by giving it a <code>speed()</code> instruction, or by setting
+        the rate of the fiber itself. The latter approach is implemented thanks to another fiber that listens to
+        <code>input</code> events from an <code>&lt;input type="range"&gt;</code> element and setting the rate of the
+        turtle fiber accordingly.</p>
         <p><span class="todo">TODO</span> Multiple turtles.</p>
         <h2>Source</h2>
         <pre></pre>

--- a/examples/turtle.html
+++ b/examples/turtle.html
@@ -54,19 +54,27 @@ const turtle = new Turtle(fiber, canvas).
     );
 
 turtle.
+    speed(4).
     penup().
     right(90).
     forward(200).
     right(90).
     forward(120).
     right(180).
+    speed(1).
     wait(500).
+    speed(0.5).
     pendown().
-    repeat(9, turtle => turtle.
+    thing(250).
+    right(10).
+    forward(125).
+    speed(4).
+    repeat(8, turtle => turtle.
         thing(250).
         right(10).
         forward(125)
     ).
+    speed(1).
     wait(700).
     hide();
 

--- a/examples/turtle.html
+++ b/examples/turtle.html
@@ -67,12 +67,8 @@ turtle.
         right(10).
         forward(125)
     ).
-    penup().
-    repeat(Infinity, turtle => turtle.
-        thing(250).
-        right(10).
-        forward(125)
-    );
+    wait(700).
+    hide();
 
         </script>
     </head>

--- a/examples/turtle.html
+++ b/examples/turtle.html
@@ -17,7 +17,7 @@ const fiber = Scheduler.run().
     spawn(fiber => fiber.
         repeat(fiber => fiber.
             effect((_, scheduler) => {
-                const rate = 1.25 ** range.value;
+                const rate = 1.26 ** range.value;
                 span.textContent = rate.toFixed(2);
                 scheduler.setRateForFiber(Fiber.byName("turtle"), rate);
             }).
@@ -93,7 +93,15 @@ turtle.
         <div class="example" style="padding: 0.5em">
             <canvas style="width: 100%; aspect-ratio: 4/3; display: block"></canvas>
             <p>
-                Turtle speed: <input type="range" min="-6" max="6" step="any"></input> <span>---</span>
+                <label for="speed">Turtle speed:</label>
+                <input type="range" name="speed" list="markers" min="-6" max="6" step="any"></input> <span>---</span>
+                <datalist id="markers">
+                    <option value="-6"></option>
+                    <option value="-3"></option>
+                    <option value="0"></option>
+                    <option value="3"></option>
+                    <option value="6"></option>
+                </datalist>
             </p>
         </div>
         <p>This example is adapted from <a href="https://direct.mit.edu/books/oa-monograph/4663/">Turtle Geometry: The

--- a/examples/turtle.html
+++ b/examples/turtle.html
@@ -53,14 +53,16 @@ const turtle = new Turtle(fiber, canvas).
         forward(size / 2)
     );
 
+const x = 200;
+const y = 120;
+const a = 90 + Math.atan2(y, x) * 180 / Math.PI;
+
 turtle.
     speed(4).
     penup().
-    right(90).
-    forward(200).
-    right(90).
-    forward(120).
-    right(180).
+    right(a).
+    forward(Math.sqrt(x * x + y * y)).
+    left(a).
     speed(1).
     wait(500).
     speed(0.5).

--- a/examples/turtle.html
+++ b/examples/turtle.html
@@ -7,11 +7,25 @@
         <link rel="stylesheet" href="style.css"/>
         <script type="module">
 import Scheduler from "../lib/scheduler.js";
+import Fiber from "../lib/fiber.js";
 import { Canvas, Turtle } from "./turtle.js";
 
-const fiber = Scheduler.run();
+const range = document.querySelector("input");
+const span = document.querySelector("span");
+
+const fiber = Scheduler.run().
+    spawn(fiber => fiber.
+        repeat(fiber => fiber.
+            effect((_, scheduler) => {
+                const rate = 1.25 ** range.value;
+                span.textContent = rate.toFixed(2);
+                scheduler.setRateForFiber(Fiber.byName("turtle"), rate);
+            }).
+            event(range, "input"), { repeatShouldEnd: () => false }
+        )
+    );
 const canvas = new Canvas(document.querySelector("canvas"));
-const turtle = new Turtle(fiber, canvas).
+const turtle = new Turtle(fiber.spawn().name("turtle"), canvas).
     to("triangle", (turtle, size) => turtle.
         repeat(3, turtle => turtle.
             forward(size).
@@ -58,25 +72,17 @@ const y = 120;
 const a = 90 + Math.atan2(y, x) * 180 / Math.PI;
 
 turtle.
-    speed(4).
     penup().
     right(a).
     forward(Math.sqrt(x * x + y * y)).
     left(a).
-    speed(1).
     wait(500).
-    speed(0.5).
     pendown().
-    thing(250).
-    right(10).
-    forward(125).
-    speed(4).
-    repeat(8, turtle => turtle.
+    repeat(9, turtle => turtle.
         thing(250).
         right(10).
         forward(125)
     ).
-    speed(1).
     wait(700).
     hide();
 
@@ -86,6 +92,9 @@ turtle.
         <h1>Animated turtle graphics example</h1>
         <div class="example" style="padding: 0.5em">
             <canvas style="width: 100%; aspect-ratio: 4/3; display: block"></canvas>
+            <p>
+                Turtle speed: <input type="range" min="-6" max="6" step="any"></input> <span>---</span>
+            </p>
         </div>
         <p>This example is adapted from <a href="https://direct.mit.edu/books/oa-monograph/4663/">Turtle Geometry: The
         Computer as a Medium for Exploring Mathematics</a>, by Harold Abelson and Andrea diSessa, MIT Press, 1981 (chapter

--- a/examples/turtle.js
+++ b/examples/turtle.js
@@ -74,6 +74,11 @@ export class Turtle {
         return this;
     }
 
+    speed(s) {
+        this.fiber.effect((fiber, scheduler) => { scheduler.setRateForFiber(fiber, s); });
+        return this;
+    }
+
     forward(d) {
         this.fiber.
             exec(() => ({

--- a/examples/turtle.js
+++ b/examples/turtle.js
@@ -92,6 +92,8 @@ export class Turtle {
                     if (this.isPenDown) {
                         context.save();
                         context.strokeStyle = this.color;
+                        context.lineJoin = "round";
+                        context.lineCap = "round";
                         context.lineWidth = 3;
                         context.translate(this.canvas.width / 2, this.canvas.height / 2);
                         context.beginPath();

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -13,22 +13,29 @@ export default class Fiber {
 
     static byName = new Map();
 
+    // Set the rate for the fiber. Rate must be greater than zero.
+    // FIXME rate = 0
+    // FIXME rate < 0
+    rate(rate) {
+        if (this.yielded || Object.hasOwn(this, "baseRate")) {
+            throw Error("Base rate already set for fiber");
+        }
+        console.assert(rate > 0);
+        this.baseRate = rate;
+        if (Object.hasOwn(this, "currentRate")) {
+            // The fiber is scheduled by is not yet running.
+            this.currentRate = rate;
+        }
+        return this;
+    }
+
+    // Set the name of the fiber so that it can be retrieved from the static
+    // `byName` map (e.g. to update the delay or set the rate.
     name(name) {
         console.assert(!Fiber.byName.has(this));
         Fiber.byName.set(name, this);
         this.id += ":" + name;
         return this;
-    }
-
-    reset(t) {
-        this.beginTime = t;
-        delete this.endTime;
-        this.ip = 0;
-        this.handleValue = [this.parent?.handleValue.at(-1) ?? true];
-        this.handleError = [this.parent?.handleError.at(-1) ?? false];
-        this.result = this.handleError.at(-1) && this.parent?.error ?
-            { error: this.parent.error } :
-            { value: this.parent?.value };
     }
 
     get value() {
@@ -55,6 +62,18 @@ export default class Fiber {
     errorWithMessage(error) {
         this.result.error = error;
         console.error(error.message ?? error);
+    }
+
+    reset(t) {
+        this.beginTime = t;
+        delete this.endTime;
+        this.currentRate = this.baseRate ?? 1;
+        this.ip = 0;
+        this.handleValue = [this.parent?.handleValue.at(-1) ?? true];
+        this.handleError = [this.parent?.handleError.at(-1) ?? false];
+        this.result = this.handleError.at(-1) && this.parent?.error ?
+            { error: this.parent.error } :
+            { value: this.parent?.value };
     }
 
     // Cancel a fiber and its pending children, if joining. This sets its error
@@ -293,7 +312,7 @@ export default class Fiber {
             }
             const effectiveDur = this.getEffectiveDuration(dur, scheduler);
             if (typeof effectiveDur === "number" && effectiveDur > 0) {
-                scheduler.delay(this, effectiveDur);
+                scheduler.delay(this, effectiveDur / this.currentRate);
             }
         });
         return this;

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -13,22 +13,6 @@ export default class Fiber {
 
     static byName = new Map();
 
-    // Set the rate for the fiber. Rate must be greater than zero.
-    // FIXME rate = 0
-    // FIXME rate < 0
-    rate(rate) {
-        if (this.yielded || Object.hasOwn(this, "baseRate")) {
-            throw Error("Base rate already set for fiber");
-        }
-        console.assert(rate > 0);
-        this.baseRate = rate;
-        if (Object.hasOwn(this, "currentRate")) {
-            // The fiber is scheduled by is not yet running.
-            this.currentRate = rate;
-        }
-        return this;
-    }
-
     // Set the name of the fiber so that it can be retrieved from the static
     // `byName` map (e.g. to update the delay or set the rate.
     name(name) {
@@ -67,7 +51,7 @@ export default class Fiber {
     reset(t) {
         this.beginTime = t;
         delete this.endTime;
-        this.currentRate = this.baseRate ?? 1;
+        this.rate = 1;
         this.ip = 0;
         this.handleValue = [this.parent?.handleValue.at(-1) ?? true];
         this.handleError = [this.parent?.handleError.at(-1) ?? false];
@@ -312,7 +296,7 @@ export default class Fiber {
             }
             const effectiveDur = this.getEffectiveDuration(dur, scheduler);
             if (typeof effectiveDur === "number" && effectiveDur > 0) {
-                scheduler.delay(this, effectiveDur / this.currentRate);
+                scheduler.delay(this, effectiveDur / this.rate);
             }
         });
         return this;

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -1,23 +1,23 @@
 import { isAsync, remove, on, off, parseOffsetValue } from "./util.js";
 
-let k = 0;
-
 const Cancelled = Error("cancelled");
 
 export default class Fiber {
+    static #count = 0;
+    static #fibers = new Map();
+    static byName = name => Fiber.#fibers.get(name);
+
     constructor(parent) {
         this.parent = parent;
-        this.id = k++;
+        this.id = Fiber.#count++;
         this.ops = [];
     }
-
-    static byName = new Map();
 
     // Set the name of the fiber so that it can be retrieved from the static
     // `byName` map (e.g. to update the delay or set the rate.
     name(name) {
-        console.assert(!Fiber.byName.has(this));
-        Fiber.byName.set(name, this);
+        console.assert(!Fiber.#fibers.has(this));
+        Fiber.#fibers.set(name, this);
         this.id += ":" + name;
         return this;
     }

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -69,7 +69,7 @@ export default class Scheduler {
         console.assert(!this.delays.has(fiber) && !this.ramps.has(fiber));
         const begin = this.now;
         const end = begin + dur;
-        this.delays.set(fiber, begin);
+        this.delays.set(fiber, { begin, dur });
         fiber.yielded = true;
         this.resume(fiber, end);
     }
@@ -79,9 +79,10 @@ export default class Scheduler {
         const begin = this.now;
         delegate = Object.create(delegate ?? {});
         delegate.rampDidProgress?.call(delegate, 0, fiber, this);
-        this.ramps.set(fiber, { delegate, begin, dur });
+        const rate = fiber.currentRate;
+        this.ramps.set(fiber, { delegate, begin, dur, rate });
         fiber.yielded = true;
-        this.resume(fiber, begin + dur);
+        this.resume(fiber, begin + dur / rate);
     }
 
     endRamp(fiber) {
@@ -90,19 +91,31 @@ export default class Scheduler {
         delegate.rampDidProgress?.call(delegate, 1, fiber, this);
     }
 
-    hasDelay(fiber) {
-        return this.delays.has(fiber) || this.ramps.has(fiber);
-    }
-
-    updateDelay(fiber, dur) {
+    // Update the current delay or ramp duration for the fiber, if any.
+    updateDelayForFiber(fiber, dur) {
         if (this.delays.has(fiber)) {
-            const begin = this.delays.get(fiber);
+            const { begin } = this.delays.get(fiber);
             this.reschedule(fiber, Math.max(begin + dur, this.now));
-        } else {
+        } else if (this.ramps.has(fiber)) {
             const ramp = this.ramps.get(fiber);
             ramp.dur = dur;
             this.reschedule(fiber, Math.max(ramp.begin + dur, this.now));
         }
+    }
+
+    // Set a new rate for the fiber. If it has a current delay or ramp, update
+    // its duration as well to reflect the change.
+    // TODO multiple changes of the rate for the same delay (needs local time).
+    setRateForFiber(fiber, rate) {
+        console.assert(rate > 0);
+        if (this.delays.has(fiber)) {
+            const { begin, dur } = this.delays.get(fiber);
+            const newDuration = (dur - this.now + begin) / rate;
+            this.reschedule(fiber, newDuration);
+        } else if (this.ramps.has(fiber)) {
+            throw Error("TODO");
+        }
+        fiber.currentRate = rate;
     }
 
     update(begin, end) {
@@ -130,8 +143,8 @@ export default class Scheduler {
             delete this.currentTime;
             delete this.resumeQueues;
         }
-        for (const [fiber, { delegate, begin, dur }] of this.ramps.entries()) {
-            const p = (end - begin) / dur;
+        for (const [fiber, { delegate, begin, dur, rate }] of this.ramps.entries()) {
+            const p = (end - begin) / dur * rate;
             console.assert(p >= 0 && p <= 1);
             if (p < 1) {
                 // The delegate is called with p = 1 when the ramp ends.

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -112,7 +112,7 @@ export default class Scheduler {
             const newDuration = (dur - this.now + begin) / rate;
             this.reschedule(fiber, newDuration);
         } else if (this.ramps.has(fiber)) {
-            throw Error("TODO");
+            // TODO
         }
         fiber.rate = rate;
     }

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -79,7 +79,7 @@ export default class Scheduler {
         const begin = this.now;
         delegate = Object.create(delegate ?? {});
         delegate.rampDidProgress?.call(delegate, 0, fiber, this);
-        const rate = fiber.currentRate;
+        const rate = fiber.rate;
         this.ramps.set(fiber, { delegate, begin, dur, rate });
         fiber.yielded = true;
         this.resume(fiber, begin + dur / rate);
@@ -105,7 +105,6 @@ export default class Scheduler {
 
     // Set a new rate for the fiber. If it has a current delay or ramp, update
     // its duration as well to reflect the change.
-    // TODO multiple changes of the rate for the same delay (needs local time).
     setRateForFiber(fiber, rate) {
         console.assert(rate > 0);
         if (this.delays.has(fiber)) {
@@ -115,7 +114,7 @@ export default class Scheduler {
         } else if (this.ramps.has(fiber)) {
             throw Error("TODO");
         }
-        fiber.currentRate = rate;
+        fiber.rate = rate;
     }
 
     update(begin, end) {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -104,15 +104,27 @@ export default class Scheduler {
     }
 
     // Set a new rate for the fiber. If it has a current delay or ramp, update
-    // its duration as well to reflect the change.
+    // its duration as well to reflect the change. Also adjust the begin time
+    // of the ramp to reflect the change of rate from this point on.
+    // FIXME 4H02 Fiber rate = 0
+    // FIXME 4H03 Fiber rate < 0
+    // FIXME 4H04 Fiber rate = ∞
     setRateForFiber(fiber, rate) {
         console.assert(rate > 0);
+        if (rate === fiber.rate) {
+            return;
+        }
         if (this.delays.has(fiber)) {
             const { begin, dur } = this.delays.get(fiber);
-            const newDuration = (dur - this.now + begin) / rate;
-            this.reschedule(fiber, newDuration);
+            this.reschedule(fiber, (dur - this.now + begin) / rate);
         } else if (this.ramps.has(fiber)) {
-            // TODO
+            const ramp = this.ramps.get(fiber);
+            const now = this.now;
+            const p = (now - ramp.begin) / (ramp.dur / ramp.rate);
+            const dur = ramp.dur / rate;
+            ramp.rate = rate;
+            ramp.begin = now - p * dur;
+            this.reschedule(fiber, now + (1 - p) * dur);
         }
         fiber.rate = rate;
     }
@@ -143,7 +155,7 @@ export default class Scheduler {
             delete this.resumeQueues;
         }
         for (const [fiber, { delegate, begin, dur, rate }] of this.ramps.entries()) {
-            const p = (end - begin) / dur * rate;
+            const p = (end - begin) / (dur / rate);
             console.assert(p >= 0 && p <= 1);
             if (p < 1) {
                 // The delegate is called with p = 1 when the ramp ends.

--- a/test/index.js
+++ b/test/index.js
@@ -234,7 +234,7 @@ test("Fiber.name(name)", t => {
     const fiber = new Fiber();
     t.same(fiber.name("foo"), fiber, "returns the fiber");
     t.match(fiber.id, /\bfoo\b/, `is part of the fiber id (${fiber.id})`);
-    t.same(Fiber.byName.get("foo"), fiber, "allows finding the fiber by its name");
+    t.same(Fiber.byName("foo"), fiber, "allows finding the fiber by its name");
 });
 
 test("Fiber.exec(f)", t => {
@@ -1268,7 +1268,7 @@ test("Scheduler.setRateForFiber() sets the rate of the fiber when running", t =>
         ).
         spawn(fiber => fiber.
             delay(222).
-            effect((_, scheduler) => { scheduler.setRateForFiber(Fiber.byName.get("delay"), 2); })
+            effect((_, scheduler) => { scheduler.setRateForFiber(Fiber.byName("delay"), 2); })
         );
     run(fiber);
 });
@@ -1307,7 +1307,7 @@ test("Scheduler.setRateForFiber() sets the rate of the fiber for ramps as well w
         spawn(fiber => fiber.
             delay(100).
             effect((_, scheduler) => {
-                scheduler.setRateForFiber(Fiber.byName.get("ramp"), 3);
+                scheduler.setRateForFiber(Fiber.byName("ramp"), 3);
             })
         );
     const scheduler = run(fiber, new Scheduler(), 80);

--- a/test/index.js
+++ b/test/index.js
@@ -1115,36 +1115,36 @@ test("Fiber.delay(dur) has no effect when the duration cannot be parsed", t => {
 
 // 4G0G Dynamic delay duration
 
-test("Scheduler.updateDelay(fiber) can set a new (longer) duration for an ongoing delay", t => {
+test("Scheduler.updateDelayForFiber(fiber) can set a new (longer) duration for an ongoing delay", t => {
     const fiber = new Fiber().
         delay(777).
         effect((_, scheduler) => {
             t.same(scheduler.now, 999, "delay was lenghtened");
         });
     const scheduler = run(fiber, new Scheduler(), 666);
-    scheduler.updateDelay(fiber, 999);
+    scheduler.updateDelayForFiber(fiber, 999);
     scheduler.clock.now = Infinity;
 });
 
-test("Scheduler.updateDelay(fiber) can set a new (shorter) duration for an ongoing delay", t => {
+test("Scheduler.updateDelayForFiber(fiber) can set a new (shorter) duration for an ongoing delay", t => {
     const fiber = new Fiber().
         delay(777).
         effect((_, scheduler) => {
             t.same(scheduler.now, 444, "delay was shortened");
         });
     const scheduler = run(fiber, new Scheduler(), 200);
-    scheduler.updateDelay(fiber, 444);
+    scheduler.updateDelayForFiber(fiber, 444);
     scheduler.clock.now = Infinity;
 });
 
-test("Scheduler.updateDelay(fiber) can set a new (shorter) duration for an ongoing delay", t => {
+test("Scheduler.updateDelayForFiber(fiber) can set a new (shorter) duration for an ongoing delay", t => {
     const fiber = new Fiber().
         delay(777).
         effect((_, scheduler) => {
             t.same(scheduler.now, 200, "delay ended now");
         });
     const scheduler = run(fiber, new Scheduler(), 200);
-    scheduler.updateDelay(fiber, 111);
+    scheduler.updateDelayForFiber(fiber, 111);
     scheduler.clock.now = Infinity;
 });
 
@@ -1200,35 +1200,113 @@ test("Fiber.ramp(Infinity, delegate) creates an infinite ramp", t => {
     scheduler.clock.now = 777;
 });
 
-test("Scheduler.updateDelay(fiber) can set a new (longer) duration for an ongoing ramp", t => {
+test("Scheduler.updateDelayForFiber(fiber) can set a new (longer) duration for an ongoing ramp", t => {
     const fiber = new Fiber().
         ramp(777).
         effect((_, scheduler) => {
             t.same(scheduler.now, 999, "ramp duration was lenghtened");
         });
     const scheduler = run(fiber, new Scheduler(), 666);
-    scheduler.updateDelay(fiber, 999);
+    scheduler.updateDelayForFiber(fiber, 999);
     scheduler.clock.now = Infinity;
 });
 
-test("Scheduler.updateDelay(fiber) can set a new (shorter) duration for an ongoing ramp", t => {
+test("Scheduler.updateDelayForFiber(fiber) can set a new (shorter) duration for an ongoing ramp", t => {
     const fiber = new Fiber().
         ramp(777).
         effect((_, scheduler) => {
             t.same(scheduler.now, 444, "ramp duration was shortened");
         });
     const scheduler = run(fiber, new Scheduler(), 200);
-    scheduler.updateDelay(fiber, 444);
+    scheduler.updateDelayForFiber(fiber, 444);
     scheduler.clock.now = Infinity;
 });
 
-test("Scheduler.updateDelay(fiber) can set a new (shorter) duration for an ongoing ramp", t => {
+test("Scheduler.updateDelayForFiber(fiber) can set a new (shorter) duration for an ongoing ramp", t => {
     const fiber = new Fiber().
         delay(777).
         effect((_, scheduler) => {
             t.same(scheduler.now, 200, "ramp ended now");
         });
     const scheduler = run(fiber, new Scheduler(), 200);
-    scheduler.updateDelay(fiber, 111);
+    scheduler.updateDelayForFiber(fiber, 111);
     scheduler.clock.now = Infinity;
+});
+
+test("Scheduler.updateDelayForFiber(fiber) has no effect when the fiber is not being delayed", t => {
+    const fiber = new Fiber().
+        event(window, "hello").
+        effect((_, scheduler) => {
+            t.same(scheduler.now, 1111, "fiber ended at the expected time");
+        });
+    const scheduler = run(fiber, new Scheduler(), 200);
+    scheduler.updateDelayForFiber(fiber, 111);
+    scheduler.clock.now = 1111;
+    window.dispatchEvent(new CustomEvent("hello"));
+    scheduler.clock.now = Infinity;
+});
+
+// 4C08 Fiber rate > 0
+
+test("Fiber.rate() sets the base rate of the fiber", t => {
+    const fiber = new Fiber().
+        delay(888).
+        rate(2).
+        effect((_, scheduler) => {
+            t.same(scheduler.now, 444, "delay was halved as rate was set to 2");
+        });
+    run(fiber);
+});
+
+test("Fiber.rate() fails when the fiber is not at rest", t => {
+    t.expectsError = true;
+    const fiber = new Fiber().
+        spawn(fiber => fiber.name("delay").
+            delay(888).
+            effect((_, scheduler) => {
+                t.same(scheduler.now, 888, "delay was not halved");
+            })
+        ).
+        spawn(fiber => fiber.
+            delay(333).
+            effect(() => { Fiber.byName.get("delay").rate(2); })
+        );
+    run(fiber);
+});
+
+test("Scheduler.setRateForFiber() sets the rate of the fiber when running", t => {
+    const fiber = new Fiber().
+        spawn(fiber => fiber.name("delay").
+            delay(888).
+            effect((_, scheduler) => {
+                t.same(scheduler.now, 333, "delay was shortened as rate was set to 2");
+            })
+        ).
+        spawn(fiber => fiber.
+            delay(222).
+            effect((_, scheduler) => { scheduler.setRateForFiber(Fiber.byName.get("delay"), 2); })
+        );
+    run(fiber);
+});
+
+test("Fiber.rate() affects ramps as well as delays", t => {
+    const ps = [0, 0.1, 0.5, 1];
+    const fiber = new Fiber().
+        ramp(400, {
+            rampDidProgress(p) {
+                t.same(p, ps.shift(), `ramp did progress (${p})`);
+            }
+        }).
+        rate(0.5).
+        effect((_, scheduler) => {
+            t.same(scheduler.now, 800, "ramp duration was doubled as rate was set to 0.5");
+        });
+    const scheduler = run(fiber, new Scheduler(), 80);
+    scheduler.clock.now = 400;
+    scheduler.clock.now = Infinity;
+    t.equal(ps, [], "ramp went through all steps");
+});
+
+test("Scheduler.setRateForFiber() affects ramps", t => {
+    t.todo();
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1248,29 +1248,13 @@ test("Scheduler.updateDelayForFiber(fiber) has no effect when the fiber is not b
 
 // 4C08 Fiber rate > 0
 
-test("Fiber.rate() sets the base rate of the fiber", t => {
+test("Scheduler.setRateForFiber() sets the rate of the fiber", t => {
     const fiber = new Fiber().
+        effect((fiber, scheduler) => scheduler.setRateForFiber(fiber, 2)).
         delay(888).
-        rate(2).
         effect((_, scheduler) => {
             t.same(scheduler.now, 444, "delay was halved as rate was set to 2");
-        });
-    run(fiber);
-});
-
-test("Fiber.rate() fails when the fiber is not at rest", t => {
-    t.expectsError = true;
-    const fiber = new Fiber().
-        spawn(fiber => fiber.name("delay").
-            delay(888).
-            effect((_, scheduler) => {
-                t.same(scheduler.now, 888, "delay was not halved");
-            })
-        ).
-        spawn(fiber => fiber.
-            delay(333).
-            effect(() => { Fiber.byName.get("delay").rate(2); })
-        );
+        })
     run(fiber);
 });
 
@@ -1290,6 +1274,8 @@ test("Scheduler.setRateForFiber() sets the rate of the fiber when running", t =>
 });
 
 test("Fiber.rate() affects ramps as well as delays", t => {
+    t.todo();
+    /*
     const ps = [0, 0.1, 0.5, 1];
     const fiber = new Fiber().
         ramp(400, {
@@ -1305,6 +1291,7 @@ test("Fiber.rate() affects ramps as well as delays", t => {
     scheduler.clock.now = 400;
     scheduler.clock.now = Infinity;
     t.equal(ps, [], "ramp went through all steps");
+*/
 });
 
 test("Scheduler.setRateForFiber() affects ramps", t => {

--- a/test/index.js
+++ b/test/index.js
@@ -1273,17 +1273,15 @@ test("Scheduler.setRateForFiber() sets the rate of the fiber when running", t =>
     run(fiber);
 });
 
-test("Fiber.rate() affects ramps as well as delays", t => {
-    t.todo();
-    /*
+test("Scheduler.setRateForFiber() affects ramps as well as delays", t => {
     const ps = [0, 0.1, 0.5, 1];
     const fiber = new Fiber().
+        effect((fiber, scheduler) => { scheduler.setRateForFiber(fiber, 0.5); }).
         ramp(400, {
             rampDidProgress(p) {
                 t.same(p, ps.shift(), `ramp did progress (${p})`);
             }
         }).
-        rate(0.5).
         effect((_, scheduler) => {
             t.same(scheduler.now, 800, "ramp duration was doubled as rate was set to 0.5");
         });
@@ -1291,9 +1289,8 @@ test("Fiber.rate() affects ramps as well as delays", t => {
     scheduler.clock.now = 400;
     scheduler.clock.now = Infinity;
     t.equal(ps, [], "ramp went through all steps");
-*/
 });
 
-test("Scheduler.setRateForFiber() affects ramps", t => {
+test("Scheduler.setRateForFiber() sets the rate of the fiber for ramps as well when running", t => {
     t.todo();
 });


### PR DESCRIPTION
Add a rate property to the fiber that divides durations of delays and ramps (a higher rate makes durations shorter; a lower rate makes durations longer). Supported values are finite values greater than 0 (0, ∞ and negative values will be addressed later). One difficulty is rescheduling current delays/ramps. Events and asynchronous function calls are not affected. The turtle demo is updated to allow the user to set the turtle speed while it is running.