### PR TITLE
4H0E Fiber is removed from child list before calling delegate

### DIFF
--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -379,9 +379,7 @@ export default class Fiber {
             return;
         }
         this.joinDelegate.pending.delete(fiber);
-        const index = this.children.indexOf(fiber);
-        this.children.splice(index, 1);
-        this.joinDelegate.childFiberDidEnd?.call(this.joinDelegate, fiber, scheduler, index);
+        this.joinDelegate.childFiberDidEnd?.call(this.joinDelegate, fiber, scheduler);
         if (this.joinDelegate.pending.size === 0) {
             delete this.children;
             delete this.joinDelegate;
@@ -397,9 +395,9 @@ export const All = {
         this.values = new Array(fiber.children.length).fill();
     },
 
-    childFiberDidEnd(child, _, index) {
+    childFiberDidEnd(child) {
         const fiber = child.parent;
-        this.values[index] = child.value;
+        this.values[fiber.children.indexOf(child)] = child.value;
         if (this.pending.size === 0) {
             fiber.value = this.values;
             delete this.values;

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -418,7 +418,6 @@ export const Last = {
         this.values.push(child.value);
         if (this.pending.size === 0) {
             child.parent.value = this.values;
-            delete this.values;
         }
     }
 };

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -1,4 +1,4 @@
-import { isAsync, remove, on, off, parseOffsetValue } from "./util.js";
+import { isAsync, on, off, parseOffsetValue } from "./util.js";
 
 const Cancelled = Error("cancelled");
 
@@ -379,8 +379,9 @@ export default class Fiber {
             return;
         }
         this.joinDelegate.pending.delete(fiber);
-        remove(this.children, fiber);
-        this.joinDelegate.childFiberDidEnd?.call(this.joinDelegate, fiber, scheduler);
+        const index = this.children.indexOf(fiber);
+        this.children.splice(index, 1);
+        this.joinDelegate.childFiberDidEnd?.call(this.joinDelegate, fiber, scheduler, index);
         if (this.joinDelegate.pending.size === 0) {
             delete this.children;
             delete this.joinDelegate;
@@ -393,15 +394,14 @@ export default class Fiber {
 // FIXME 4F04 Handle errors when joining
 export const All = {
     fiberWillJoin(fiber) {
-        this.values = new Array(fiber.children.length);
+        this.values = new Array(fiber.children.length).fill();
     },
 
-    childFiberDidEnd(child) {
+    childFiberDidEnd(child, _, index) {
         const fiber = child.parent;
-        const index = fiber.children.indexOf(child);
         this.values[index] = child.value;
         if (this.pending.size === 0) {
-            child.parent.value = this.values;
+            fiber.value = this.values;
             delete this.values;
         }
     }

--- a/test/index.js
+++ b/test/index.js
@@ -682,7 +682,7 @@ test("Fiber.join() is a noop if there are no child fibers", t => {
 test("Fiber.join(delegate) calls the `fiberWillJoin` delegate method before yielding", t => {
     const delegate = {
         fiberWillJoin(...args) {
-            t.equal(args, [fiber, scheduler], "`fiberWillJoin` is called with `fiber`, `scheduler` as arguments");
+            t.equal(args, [fiber, scheduler], "`fiberWillJoin` is called with `fiber` and `scheduler` as arguments");
             t.same(Object.getPrototypeOf(this), delegate, "and `this` is a copy of the delegate object");
         }
     };

--- a/test/index.js
+++ b/test/index.js
@@ -682,7 +682,7 @@ test("Fiber.join() is a noop if there are no child fibers", t => {
 test("Fiber.join(delegate) calls the `fiberWillJoin` delegate method before yielding", t => {
     const delegate = {
         fiberWillJoin(...args) {
-            t.equal(args, [fiber, scheduler], "`fiberWillJoin` is called with `fiber` and `scheduler` as arguments");
+            t.equal(args, [fiber, scheduler], "`fiberWillJoin` is called with `fiber`, `scheduler` as arguments");
             t.same(Object.getPrototypeOf(this), delegate, "and `this` is a copy of the delegate object");
         }
     };
@@ -699,8 +699,8 @@ test("Fiber.join(delegate) calls the `childFiberDidEnd` delegate when a child fi
         childFiberDidEnd(...args) {
             t.equal(
                 args,
-                [child, scheduler],
-                "`fiberWillJoin` is called with `fiber` (the child fiber) and `scheduler` as arguments"
+                [child, scheduler, 0],
+                "`fiberWillJoin` is called with `fiber` (the child fiber), `scheduler` and `index` (of the child fiber) as arguments"
             );
             t.same(Object.getPrototypeOf(this), delegate, "and `this` is the delegate object");
         }

--- a/test/index.js
+++ b/test/index.js
@@ -699,8 +699,8 @@ test("Fiber.join(delegate) calls the `childFiberDidEnd` delegate when a child fi
         childFiberDidEnd(...args) {
             t.equal(
                 args,
-                [child, scheduler, 0],
-                "`fiberWillJoin` is called with `fiber` (the child fiber), `scheduler` and `index` (of the child fiber) as arguments"
+                [child, scheduler],
+                "`fiberWillJoin` is called with `fiber` (the child fiber) and `scheduler` as arguments"
             );
             t.same(Object.getPrototypeOf(this), delegate, "and `this` is the delegate object");
         }


### PR DESCRIPTION
Do not remove from the child list to keep consistent ordering of the children. The test was a false positive because the equality check itself was failing (!); fill the values array to avoid this issue.