### PR TITLE
4J0A Delay setting fiber parent

### DIFF
--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -6,8 +6,7 @@ export default class Fiber {
     #name;
     static #count = 0;
 
-    constructor(parent) {
-        this.parent = parent;
+    constructor() {
         this.id = Fiber.#count++;
         this.ops = [];
     }
@@ -409,7 +408,7 @@ export default class Fiber {
     // as its only argument and the current fiber is returned. The child fiber
     // will then begin after the parent fiber yields, in the same instant.
     spawn(f) {
-        const child = new Fiber(this);
+        const child = new Fiber();
         this.ops.push(function(scheduler) {
             if (this.handleResult) {
                 this.attach(scheduler, child);
@@ -428,7 +427,7 @@ export default class Fiber {
             if (!this.handleResult) {
                 return;
             }
-            const template = new Fiber(this);
+            const template = new Fiber();
             f(template);
             const type = this.error ? "error" : typeOf(this.value);
             const values =
@@ -443,7 +442,7 @@ export default class Fiber {
                 }
             } else if (type === "map" || type === "object") {
                 for (const [key, value] of values) {
-                    const child = this.attach(scheduler, new Fiber(this).named(key));
+                    const child = this.attach(scheduler, new Fiber().named(key));
                     child.ops = template.ops;
                     child.result = { value };
                 }
@@ -458,8 +457,9 @@ export default class Fiber {
     // be used to add new child fibers while the parent is still joining.
     attach(scheduler, child) {
         if (!child) {
-            child = new Fiber(this);
+            child = new Fiber();
         }
+        child.parent = this;
         if (!this.children) {
             this.children = [];
         }

--- a/test/index.js
+++ b/test/index.js
@@ -581,13 +581,14 @@ test("Fiber.delay(dur): dur function may be evaluated several times", t => {
 test("Fiber.spawn() creates a new fiber immediately", t => {
     const fiber = new Fiber();
     const child = fiber.spawn();
-    t.same(child.parent, fiber, "the new fiber has a parent");
+    t.true(child !== fiber && child instanceof Fiber, "the child fiber is returned");
 });
 
 test("Fiber.spawn(f) creates a new fiber immediately", t => {
     const fiber = new Fiber();
     t.same(fiber.spawn(child => {
-        t.same(child.parent, fiber, "the function parameter is called with the child fiber as argument")
+        t.true(child !== fiber && child instanceof Fiber,
+            "the function parameter is called with the child fiber as argument")
     }), fiber, "but the parent fiber is returned");
 });
 
@@ -1917,5 +1918,16 @@ test("Names can be reused a different times", t => {
             { repeatShouldEnd: n => n > 7 }
         ).
         effect(({ value: [_, n] }) => { t.same(n, 34, "repeated fib to compute value"); })
+    );
+});
+
+// 4J0A Delay setting fiber parent
+test("Fiber is attached to its parent dynamically", t => {
+    let sum = 0;
+    run(new Fiber().
+        exec(K([[1, 2, 3]])).
+        map(fiber => fiber.each(fiber => fiber.effect(({ value }) => { sum += value; }))).
+        join().
+        effect(() => { t.same(sum, 6, "nesting each within par attaches fibers correctly"); })
     );
 });


### PR DESCRIPTION
Do not set parent when creating the fiber, but when attaching it.