### PR TITLE
4J0D Name a running fiber

### DIFF
--- a/examples/timer.html
+++ b/examples/timer.html
@@ -68,7 +68,6 @@ Scheduler.run().
             running and will stop when it runs its course or gets set to a shorter time than currently elapsed. It
             resets one seconds after finishing.
         </p>
-        <p><span class="todo">TODO</span> 4K09 Timer demo misbehaves when setting minimum time</p>
         <p><span class="todo">TODO</span> Analog timer (with second hand).</p>
         <p>
             This example is inspired by <a href="https://eugenkiss.github.io/7guis/tasks/#timer">7GUIs: A GUI Programming

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -15,21 +15,6 @@ export default class Fiber {
         return this.#name;
     }
 
-    // Set the name of the fiber so that it can be retrieved from the scheduler
-    // map of active fibers. The fiber should not be renamed, nor should its
-    // name be set while running.
-    named(name) {
-        if (this.#name !== undefined) {
-            throw Error("Cannot rename a fiber");
-        }
-        if (this.ip >= 0) {
-            throw Error("Cannot name a fiber while it is running");
-        }
-        this.#name = name;
-        this.id += ":" + name.toString();
-        return this;
-    }
-
     get value() {
         if (this.result.error) {
             return;
@@ -62,14 +47,35 @@ export default class Fiber {
     }
 
     // Call the function f with this fiber as a parameter.
+    // FIXME 4K07 Rename lift to macro
     lift(f) {
         f(this);
         return this;
     }
 
+    // Convenience method to add new ops to the fiber, returning it for
+    // chaining.
     #op(op) {
         this.ops.push(op);
         return this;
+    }
+
+    // Set the name of the fiber so that it can be retrieved from the scheduler
+    // map of active fibers. It is an error to name the fiber with the same
+    // name as another running fiber.
+    named(name) {
+        return this.#op(function(scheduler) {
+            if (!this.handleResult || name === this.#name) {
+                return;
+            }
+            try {
+                scheduler.setNameForFiber(this, name);
+                this.#name = name;
+                this.id += ":" + name.toString();
+            } catch (error) {
+                this.errorWithMessage(error);
+            }
+        });
     }
 
     // Call a function with this and the scheduler as parameters, and set the
@@ -419,15 +425,9 @@ export default class Fiber {
                 type === "set" ? this.value.values() :
                 type === "map" ? this.value.entries() :
                 type === "object" ? Object.entries(this.value) : this.value;
-            if (type === "array" || type === "set") {
+            if (type === "array" || type === "set" || type === "map" || type === "object") {
                 for (const value of values) {
                     const child = scheduler.attachFiber(this);
-                    child.ops = template.ops;
-                    child.result = { value };
-                }
-            } else if (type === "map" || type === "object") {
-                for (const [key, value] of values) {
-                    const child = scheduler.attachFiber(this, new Fiber().named(key));
                     child.ops = template.ops;
                     child.result = { value };
                 }

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -121,12 +121,6 @@ export default class Scheduler {
     // sechduler, its ip to 0, and initializing various state from the parent
     // fiber.
     resetFiber(fiber) {
-        if (fiber.name !== undefined) {
-            if (this.#fibersByName.has(fiber.name)) {
-                throw Error("A fiber with the same name is already running");
-            }
-            this.#fibersByName.set(fiber.name, fiber);
-        }
         fiber.beginTime = this.now;
         delete fiber.endTime;
         fiber.rate = fiber.parent?.rate ?? 1;
@@ -137,6 +131,18 @@ export default class Scheduler {
         fiber.result = fiber.handleError.at(-1) && fiber.parent?.error ?
             { error: fiber.parent.error } :
             { value: fiber.parent?.value };
+    }
+
+    // Register a name for the fiber.
+    setNameForFiber(fiber, name) {
+        if (this.#fibersByName.has(name)) {
+            throw Error("A fiber with the same name is already running");
+        }
+        if (this.#fibersByName.has(fiber.name)) {
+            console.assert(this.#fibersByName.get(fiber.name) === fiber);
+            this.#fibersByName.delete(fiber.name);
+        }
+        this.#fibersByName.set(name, fiber);
     }
 
     // Cancel a fiber and its pending children, if joining. This sets its error


### PR DESCRIPTION
Name the fiber at runtime, meaning that instances can have their own name. Allow renaming as well since this is well scoped time wise. This fixes the timer demo bug as well.