### PR TITLE
4K0F Spawn reuses the same fiber within map or repeat

### DIFF
--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -409,7 +409,9 @@ export default class Fiber {
         const child = new Fiber();
         this.ops.push(function(scheduler) {
             if (this.handleResult) {
-                scheduler.attachFiber(this, child);
+                const instance = new Fiber();
+                instance.ops = child.ops;
+                scheduler.attachFiber(this, instance);
             }
         });
         if (typeof f === "function") {

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -404,14 +404,14 @@ export default class Fiber {
     // this fiber and returned, unless a function is passed as the first
     // argument, in which case that function is called with the child fiber
     // as its only argument and the current fiber is returned. The child fiber
-    // will then begin after the parent fiber yields, in the same instant.
+    // will then be instantiated (since it may be spawned multiple times, for
+    // instance within a map) and begin after the parent fiber yields, in the
+    // same instant.
     spawn(f) {
         const child = new Fiber();
         this.ops.push(function(scheduler) {
             if (this.handleResult) {
-                const instance = new Fiber();
-                instance.ops = child.ops;
-                scheduler.attachFiber(this, instance);
+                scheduler.attachFiber(this).ops = child.ops;
             }
         });
         if (typeof f === "function") {


### PR DESCRIPTION
Instantiate the fiber in spawn so that it can be reused inside e.g., map. Update Asteroids to use map for the particles.