### PR TITLE
4K0G Instantiate fibers with Object.create()

### DIFF
--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -1,4 +1,4 @@
-import { isAsync, on, off, parseOffsetValue, typeOf } from "./util.js";
+import { extend, isAsync, on, off, parseOffsetValue, typeOf } from "./util.js";
 
 export default class Fiber {
     static Names = new Map();
@@ -196,7 +196,7 @@ export default class Fiber {
             if (!effectiveTarget || !effectiveType) {
                 return;
             }
-            this.eventDelegate = Object.assign(Object.create(delegate), { target: effectiveTarget, type: effectiveType });
+            this.eventDelegate = extend(delegate, { target: effectiveTarget, type: effectiveType });
             if (effectiveTarget.addEventListener) {
                 effectiveTarget.addEventListener(effectiveType, this.eventDelegate);
                 this.eventDelegate.handleEvent = event => {
@@ -305,9 +305,7 @@ export default class Fiber {
             if (!this.handleResult) {
                 return;
             }
-            this.child = new Fiber();
-            this.child.ops = body.ops;
-            this.child.parent = this;
+            this.child = extend(body, { parent: this });
             scheduler.resetFiber(this.child);
             scheduler.resumeFiber(this.child);
             this.yielded = true;
@@ -410,7 +408,7 @@ export default class Fiber {
         const child = new Fiber();
         this.ops.push(function(scheduler) {
             if (this.handleResult) {
-                scheduler.attachFiber(this).ops = child.ops;
+                scheduler.attachFiber(this, Object.create(child));
             }
         });
         if (typeof f === "function") {
@@ -435,9 +433,7 @@ export default class Fiber {
                 type === "object" ? Object.entries(this.value) : this.value;
             if (type === "array" || type === "set" || type === "map" || type === "object") {
                 for (const value of values) {
-                    const child = scheduler.attachFiber(this);
-                    child.ops = template.ops;
-                    child.result = { value };
+                    scheduler.attachFiber(this, Object.create(template)).result = { value };
                 }
             } else {
                 scheduler.attachFiber(this, template);
@@ -459,7 +455,7 @@ export default class Fiber {
             console.assert(!this.joinDelegate);
             if (this.children) {
                 console.assert(this.children.length > 0);
-                this.joinDelegate = Object.assign(Object.create(delegate), { pending: new Set(this.children) });
+                this.joinDelegate = extend(delegate, { pending: new Set(this.children) });
                 this.joinDelegate?.fiberWillJoin?.call(this.joinDelegate, this, scheduler);
                 // FIXME 4J0E Force join
                 if (this.children.length === 0) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,12 +1,18 @@
+// Do nothing.
 export function nop() {
 }
 
+// Simple combinators (identity/Idiot Bird, constant/Kestrel).
 export const I = x => x;
 export const K = x => () => x;
 
 // Clamp x between min and max.
 export const clamp = (x, min, max) => Math.min(Math.max(x, min), max);
 
+// Extend an object by creating a new one with additional properties.
+export const extend = (x, ...props) => Object.assign(Object.create(x), ...props);
+
+// Test whether a function is declared as async.
 export const isAsync = f => Object.getPrototypeOf(f) === Object.getPrototypeOf(async function() {});
 
 // Remove the first occurrence of `x` from the array `xs` and return it.

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 import test from "./test.js";
-import { nop, clamp, remove, K, PriorityQueue, message, on, off } from "../lib/util.js";
+import { nop, clamp, extend, remove, K, PriorityQueue, message, on, off } from "../lib/util.js";
 import Fiber, { All, Last, First, Gate } from "../lib/fiber.js";
 import Scheduler from "../lib/scheduler.js";
 
@@ -26,6 +26,15 @@ test("clamp(x, min, max) clamps `x` between `min` and `max`", t => {
     t.equal(clamp(91, 17, 23), 23, "x > max");
     t.equal(clamp(17, 17, 23), 17, "x = min");
     t.equal(clamp(23, 17, 23), 23, "x = max");
+});
+
+// 4K0G	Instantiate fibers with Object.create()
+
+test("extend(x, ...props) creates a new object from x with additional properties", t => {
+    const x = { foo: 1, bar: 2 };
+    const y = extend(x, { baz: 3 }, { foo: "ok", quux: 4 });
+    t.same(x, Object.getPrototypeOf(y), "the original object is the prototype of the new object");
+    t.equal(y, { foo: "ok", bar: 2, baz: 3, quux: 4 }, "the new object has additional/updated properties");
 });
 
 // 4E0A	Priority queue

--- a/test/test.js
+++ b/test/test.js
@@ -16,8 +16,16 @@ const Equal = {
     set: (x, y) => x.difference(y).size === 0,
     number: (x, y) => isNaN(x) && isNaN(y),
     object: (x, y) => {
-        const keys = Object.keys(x);
-        return keys.length === Object.keys(y).length && keys.every(key => key in y && equal(x[key], y[key]));
+        function keys(x) {
+            const keys = [];
+            for (const key in x) {
+                keys.push(key);
+            }
+            return keys;
+        }
+        const kx = keys(x);
+        const ky = keys(y);
+        return kx.length === ky.length && kx.every(key => key in y && equal(x[key], y[key]));
     },
     map: (x, y) => {
         if (x.size !== y.size) {


### PR DESCRIPTION
Remove private properties so that instances of fibers can be created with Object.create(); introduce convenience `extend()` utility.