### PR TITLE
4K0K Undo operators

### DIFF
--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -8,6 +8,7 @@ export default class Fiber {
     constructor() {
         this.id = Fiber.Count++;
         this.ops = [];
+        this.unops = [];
     }
 
     instantiate(...props) {
@@ -75,14 +76,16 @@ export default class Fiber {
     // Evaluate a function given as argument with the fiber and scheduler,
     // or return the value as is.
     getEffectiveParameter(param, scheduler) {
-        if (typeof param !== "function") {
-            return param;
-        }
         try {
-            return param(this, scheduler);
+            return this.getEffectiveParameterUnsafe(param, scheduler);
         } catch (error) {
             this.errorWithMessage(error);
         }
+    }
+
+    // Unsafe version for use inside a try/catch.
+    getEffectiveParameterUnsafe(param, scheduler) {
+        return typeof param === "function" ? param(this, scheduler) : param;
     }
 
     // Call the function f with this fiber as a first parameter, passing all
@@ -97,20 +100,33 @@ export default class Fiber {
     // name as another running fiber.
     named(name) {
         return this.op(function(scheduler) {
-            if (!this.handleResult || name === this.name) {
+            if (!this.handleResult) {
                 return;
             }
             try {
-                const effectiveName = this.getEffectiveParameter(name, scheduler);
-                if (this.error) {
+                const effectiveName = this.getEffectiveParameterUnsafe(name, scheduler);
+                const previousName = this.name;
+                if (effectiveName === previousName) {
                     return;
                 }
+                this.unops.push(previousName === undefined ?
+                    function(scheduler) {
+                        scheduler.removeNameForFiber(this);
+                    } : function(scheduler) {
+                        scheduler.setNameForFiber(this, previousName);
+                    }
+                );
                 if (effectiveName === undefined) {
                     scheduler.removeNameForFiber(this);
                 } else {
                     scheduler.setNameForFiber(this, effectiveName);
                 }
             } catch (error) {
+                // FIXME Handling either
+                const value = this.result.value;
+                this.unops.push(function() {
+                    this.value = value;
+                });
                 this.errorWithMessage(error);
             }
         });
@@ -119,6 +135,9 @@ export default class Fiber {
     // Store the current value of the fiber under the given name in its scope.
     store(name) {
         return this.op(function(scheduler) {
+            if (!this.handleResult) {
+                return;
+            }
             this.scope[this.getEffectiveParameter(name, scheduler)] = this.value;
         });
     }
@@ -126,7 +145,8 @@ export default class Fiber {
     // Call a function with this and the scheduler as parameters, and set the
     // value of the fiber to the return value of that function. If the function
     // is explicitly marked as being asynchronous, yield and resume once the
-    // function returns.
+    // function returns. Default undo is to revert to the previous value,
+    // treating an async call as a delay.
     // FIXME 4I04 Cancelling async exec/effect
     exec(f) {
         return this.op(isAsync(f) ? function(scheduler) {
@@ -153,6 +173,8 @@ export default class Fiber {
             if (!this.handleResult) {
                 return;
             }
+            const value = this.value;
+            this.unops.push(function() { this.value = value; });
             try {
                 this.value = f(this, scheduler);
             } catch (error) {
@@ -161,6 +183,10 @@ export default class Fiber {
         });
     }
 
+    // Effect calls the function `f` with the fiber and scheduler as arguments.
+    // `f` may be synchronous or asynchronous. The return value of `f` is
+    // discarded and the fiber value is unchanged (unless `f` mutates it as an
+    // effect).
     // FIXME 4I04 Cancelling async exec/effect
     effect(f) {
         return this.op(isAsync(f) ? function(scheduler) {
@@ -405,8 +431,15 @@ export default class Fiber {
             const effectiveDur = this.getEffectiveDuration(dur, scheduler);
             if (typeof effectiveDur === "number" && effectiveDur > 0) {
                 scheduler.setDelayForFiber(this, effectiveDur);
-                if (!this.yielded) {
+                if (this.yielded) {
+                    this.unops.push(function(scheduler) {
+                        scheduler.setDelayForFiber(this, -effectiveDur);
+                    });
+                } else {
                     this.now += effectiveDur;
+                    this.unops.push(function() {
+                        this.now -= effectiveDur;
+                    });
                 }
             }
         });

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -138,7 +138,19 @@ export default class Fiber {
             if (!this.handleResult) {
                 return;
             }
-            this.scope[this.getEffectiveParameter(name, scheduler)] = this.value;
+            const effectiveName = this.getEffectiveParameter(name, scheduler);
+            if (effectiveName !== undefined) {
+                const shadowed = Object.hasOwn(this.scope, effectiveName);
+                const previous = this.scope[effectiveName];
+                this.unops.push(() => {
+                    if (shadowed) {
+                        this.scope[effectiveName] = previous;
+                    } else {
+                        delete this.scope[effectiveName];
+                    }
+                });
+                this.scope[effectiveName] = this.value;
+            }
         });
     }
 

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -8,7 +8,6 @@ export default class Fiber {
     constructor() {
         this.id = Fiber.Count++;
         this.ops = [];
-        this.unops = [];
     }
 
     instantiate(...props) {

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -237,6 +237,7 @@ export default class Fiber {
     //   suspended until an event is received and not ignore).
     // * `eventWasHandled` allows calling functions like `preventDefault`
     //   before the fiber resumes.
+    // Undo is simply a negative delay.
     event(target, type, delegate = {}) {
         return this.op(function(scheduler) {
             console.assert(!this.eventDelegate);
@@ -257,10 +258,7 @@ export default class Fiber {
                         return;
                     }
                     effectiveTarget.removeEventListener(effectiveType, this.eventDelegate);
-                    this.eventDelegate.eventWasHandled?.call(delegate, event, this, scheduler);
-                    delete this.eventDelegate;
-                    this.now = scheduler.fiberLocalTime(this);
-                    scheduler.resumeFiber(this, scheduler.clock.now);
+                    this.eventWasHandled(scheduler, delegate, event);
                 };
             } else {
                 on(effectiveTarget, effectiveType, this.eventDelegate);
@@ -270,14 +268,25 @@ export default class Fiber {
                         return;
                     }
                     off(effectiveTarget, effectiveType, this.eventDelegate);
-                    this.eventDelegate.eventWasHandled?.call(delegate, message, this, scheduler);
-                    delete this.eventDelegate;
-                    this.now = scheduler.fiberLocalTime(this);
-                    scheduler.resumeFiber(this, scheduler.clock.now);
+                    this.eventWasHandled(scheduler, delegate, message);
                 };
             }
             this.yielded = true;
         });
+    }
+
+    // Event or message was handled: call the delegate method and resume the
+    // fiber.
+    eventWasHandled(scheduler, delegate, event) {
+        this.eventDelegate.eventWasHandled?.call(delegate, event, this, scheduler);
+        delete this.eventDelegate;
+        const begin = this.now;
+        this.now = scheduler.fiberLocalTime(this);
+        const delay = begin - this.now;
+        this.unops.push(function(scheduler) {
+            scheduler.setDelayForFiber(this, delay);
+        });
+        scheduler.resumeFiber(this, scheduler.clock.now);
     }
 
     // Normally fiber execution skips over errors, but either allows handling

--- a/lib/fiber.js
+++ b/lib/fiber.js
@@ -122,7 +122,7 @@ export default class Fiber {
                     scheduler.setNameForFiber(this, effectiveName);
                 }
             } catch (error) {
-                // FIXME Handling either
+                // FIXME 4L01 Undo either
                 const value = this.result.value;
                 this.unops.push(function() {
                     this.value = value;
@@ -160,6 +160,7 @@ export default class Fiber {
     // function returns. Default undo is to revert to the previous value,
     // treating an async call as a delay.
     // FIXME 4I04 Cancelling async exec/effect
+    // FIXME 4L01 Undo either
     exec(f) {
         return this.op(isAsync(f) ? function(scheduler) {
             if (!this.handleResult) {
@@ -168,15 +169,30 @@ export default class Fiber {
             f(this, scheduler).
                 then(value => {
                     if (this.handleResult) {
+                        const value = this.value;
+                        const begin = this.now;
                         this.value = value;
                         this.now = scheduler.fiberLocalTime(this);
+                        const delay = begin - this.now;
+                        this.unops.push(function(scheduler) {
+                            this.value = value;
+                            scheduler.setDelayForFiber(this, delay);
+                        });
                         scheduler.resumeFiber(this, scheduler.clock.now);
                     }
                 }).
                 catch(error => {
                     if (this.handleResult) {
+                        const value = this.value;
                         this.errorWithMessage(error);
+                        const begin = this.now;
+                        this.value = value;
                         this.now = scheduler.fiberLocalTime(this);
+                        const delay = begin - this.now;
+                        this.unops.push(function(scheduler) {
+                            this.value = value;
+                            scheduler.setDelayForFiber(this, delay);
+                        });
                         scheduler.resumeFiber(this, scheduler.clock.now);
                     }
                 });
@@ -209,7 +225,12 @@ export default class Fiber {
                 catch(error => { this.errorWithMessage(error); }).
                 finally(() => {
                     if (this.handleResult) {
-                        this.now = sheduler.fiberLocalTime(this);
+                        const begin = this.now;
+                        this.now = scheduler.fiberLocalTime(this);
+                        const delay = begin - this.now;
+                        this.unops.push(function(scheduler) {
+                            scheduler.setDelayForFiber(this, delay);
+                        });
                         scheduler.resumeFiber(this, scheduler.clock.now);
                     }
                 });
@@ -415,6 +436,7 @@ export default class Fiber {
     // exact time when the ramp starts and p=1 exactly when the ramp ends; in
     // between, it may get called with 0 < p < 1 increasing at various times
     // within the duration. When duration is infinite however, p is always 0.
+    // Undoing simply runs the ramp backward.
     // FIXME 4E02 Count iterations for (infinite) ramps
     ramp(dur, delegate) {
         if (typeof dur === "function") {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -230,10 +230,15 @@ export default class Scheduler {
     // pending (e.g., the fiber is not actually joining).
     fiberEnded(fiber) {
         this.removeNameForFiber(fiber);
-        console.assert(fiber.ip === fiber.ops.length);
+        console.assert((fiber.rate > 0 && fiber.ip === fiber.ops.length) || (fiber.rate < 0 && fiber.unip === 0));
         delete fiber.ip;
-        fiber.endTime = this.now;
+        delete fiber.unip;
         delete fiber.now;
+        if (fiber.rate < 0) {
+            // FIXME unspawn
+            return;
+        }
+        fiber.endTime = this.now;
         const parent = fiber.parent;
         if (!parent?.joinDelegate?.pending.has(fiber)) {
             return;
@@ -273,9 +278,7 @@ export default class Scheduler {
     // rate for the child fiber as well by multiplying the child’s own rate
     // with the new rate; do not set the own rate of the children though (so
     // that they can resume at the right rate after pausing, for instance).
-    // FIXME 4H03 Fiber rate < 0
     setRateForFiber(fiber, rate, setOwnRate = true) {
-        console.assert(rate >= 0);
         if (rate === fiber.rate) {
             return;
         }
@@ -295,6 +298,9 @@ export default class Scheduler {
         };
         if (setOwnRate) {
             fiber.ownRate = rate;
+        }
+        if (fiber.rate >= 0 && rate < 0) {
+            fiber.unip = fiber.unops.length;
         }
         fiber.rate = rate;
         if (this.delays.has(fiber)) {
@@ -324,6 +330,8 @@ export default class Scheduler {
         console.assert(this.instants.length === 0 || this.instants[0] >= begin);
         while (this.instants.length > 0 && this.instants[0] >= begin && this.instants[0] < end) {
             this.now = this.instants.remove();
+            // FIXME 4K0L Custom undo
+            this.lastInstant = this.now;
             const queue = this.fibersByInstant.get(this.now);
             this.fibersByInstant.delete(this.now);
             while (queue.length > 0) {
@@ -337,8 +345,14 @@ export default class Scheduler {
                 delete fiber.yielded;
                 fiber.lastUpdateTime = this.now;
                 this.resumeQueues = [[], []];
-                for (const n = fiber.ops.length; !fiber.yielded && fiber.ip < n;) {
-                    fiber.ops[fiber.ip++].call(fiber, this);
+                while (!fiber.yielded) {
+                    if (fiber.rate > 0 && fiber.ip < fiber.ops.length) {
+                        fiber.ops[fiber.ip++].call(fiber, this);
+                    } else if (fiber.rate < 0 && fiber.unip > 0) {
+                        fiber.unops[--fiber.unip].call(fiber, this);
+                    } else {
+                        break;
+                    }
                 }
                 if (!fiber.yielded) {
                     this.fiberEnded(fiber);

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -133,6 +133,7 @@ export default class Scheduler {
         fiber.rate = fiber.parent?.rate ?? 1;
         fiber.ownRate = 1;
         fiber.ip = 0;
+        fiber.unops = [];
         fiber.handleValue = [fiber.parent?.handleValue.at(-1) ?? true];
         fiber.handleError = [fiber.parent?.handleError.at(-1) ?? false];
         fiber.scope = fiber.parent ? Object.create(fiber.parent.scope) : {};
@@ -233,6 +234,7 @@ export default class Scheduler {
         console.assert((fiber.rate > 0 && fiber.ip === fiber.ops.length) || (fiber.rate < 0 && fiber.unip === 0));
         delete fiber.ip;
         delete fiber.unip;
+        delete fiber.unops;
         delete fiber.now;
         if (fiber.rate < 0) {
             // FIXME unspawn

--- a/test/index.js
+++ b/test/index.js
@@ -2485,7 +2485,7 @@ test("Undo delay", t => {
     t.same(scheduler.lastInstant, 333, "delay was undone (faster)");
 });
 
-test("Undo event", t => {
+test("Undo event (DOM event)", t => {
     const fiber = new Fiber().
         event(window, "hello").
         effect((fiber, scheduler) => {
@@ -2494,6 +2494,20 @@ test("Undo event", t => {
         });
     const scheduler = run(fiber, new Scheduler(), 222);
     window.dispatchEvent(new CustomEvent("hello"));
+    scheduler.clock.now = Infinity;
+    t.same(scheduler.lastInstant, 444, "event was undone");
+});
+
+test("Undo event (message)", t => {
+    const A = {};
+    const fiber = new Fiber().
+        event(A, "hello").
+        effect((fiber, scheduler) => {
+            t.same(scheduler.now, 222, "message was received after some time");
+            scheduler.setRateForFiber(fiber, -1);
+        });
+    const scheduler = run(fiber, new Scheduler(), 222);
+    message(A, "hello");
     scheduler.clock.now = Infinity;
     t.same(scheduler.lastInstant, 444, "event was undone");
 });

--- a/test/index.js
+++ b/test/index.js
@@ -2445,6 +2445,19 @@ test("Undo named (error: duplicate name)", t => {
     t.undefined(fiber.error, "the error was undone");
 });
 
+test("Undo store", t => {
+    const fiber = new Fiber().
+        exec(K(23)).
+        store("x").
+        exec(K(17)).
+        effect(({ scope: { x } }, scheduler) => {
+            t.same(x, 23, "value was stored");
+            scheduler.setRateForFiber(fiber, -1);
+        });
+    run(fiber);
+    t.equal(fiber.scope, {}, "fiber scope is empty after undo");
+});
+
 test("Undo exec (sync)", t => {
     const fiber = new Fiber().
         exec(K(23)).

--- a/test/index.js
+++ b/test/index.js
@@ -2474,17 +2474,6 @@ test("Undo exec (sync)", t => {
     t.undefined(fiber.value, "value was unset");
 });
 
-test("Undo delay", t => {
-    const fiber = new Fiber().
-        delay(222).
-        effect((fiber, scheduler) => {
-            t.same(scheduler.now, 222, "delay elapsed");
-            scheduler.setRateForFiber(fiber, -2);
-        });
-    const scheduler = run(fiber);
-    t.same(scheduler.lastInstant, 333, "delay was undone (faster)");
-});
-
 test("Undo event (DOM event)", t => {
     const fiber = new Fiber().
         event(window, "hello").
@@ -2510,4 +2499,15 @@ test("Undo event (message)", t => {
     message(A, "hello");
     scheduler.clock.now = Infinity;
     t.same(scheduler.lastInstant, 444, "event was undone");
+});
+
+test("Undo delay", t => {
+    const fiber = new Fiber().
+        delay(222).
+        effect((fiber, scheduler) => {
+            t.same(scheduler.now, 222, "delay elapsed");
+            scheduler.setRateForFiber(fiber, -2);
+        });
+    const scheduler = run(fiber);
+    t.same(scheduler.lastInstant, 333, "delay was undone (faster)");
 });

--- a/test/index.js
+++ b/test/index.js
@@ -2395,3 +2395,79 @@ test("Fiber.named() can unname a fiber", t => {
         effect((_, scheduler) => { t.undefined(scheduler.fiberNamed("foo"), "then unnamed"); })
     );
 });
+
+// 4K0K Undo operators
+
+test("Undo named", t => {
+    const fiber = new Fiber().
+        named("foo").
+        named("bar").
+        effect((fiber, scheduler) => {
+            t.same(fiber.name, "bar", "fiber is named");
+            t.same(scheduler.fiberNamed("bar"), fiber, "and can be retrieved by its name");
+            t.undefined(scheduler.fiberNamed("foo"), "but not by its previous name");
+            scheduler.setRateForFiber(fiber, -1);
+        });
+    const scheduler = run(fiber);
+    t.undefined(fiber.name, "fiber does not have a name anymore");
+    t.undefined(scheduler.fiberNamed("bar"), "and cannot be retrieved");
+});
+
+test("Undo named (error with name)", t => {
+    t.expectsError = true;
+    const fiber = new Fiber().
+        named(() => { throw Error("AUGH"); }).
+        either(fiber => fiber.
+            effect((fiber, scheduler) => {
+                t.same(fiber.error.message, "AUGH", "the error is caught");
+                scheduler.setRateForFiber(fiber, -1);
+            })
+        );
+    run(fiber);
+    t.undefined(fiber.error, "the error was undone");
+});
+
+test("Undo named (error: duplicate name)", t => {
+    t.expectsError = true;
+    const fiber = new Fiber().
+        named("foo").
+        either(fiber => fiber.
+            effect(({ error }, scheduler) => {
+                t.ok(error, "naming the fiber failed");
+                scheduler.setRateForFiber(fiber, -1);
+            })
+        );
+    run(new Fiber().
+        named("foo").
+        effect((parent, scheduler) => { scheduler.attachFiber(parent, fiber); }).
+        join()
+    );
+    t.undefined(fiber.error, "the error was undone");
+});
+
+test("Undo exec (sync)", t => {
+    const fiber = new Fiber().
+        exec(K(23)).
+        effect((fiber, value) => {
+            t.same(fiber.rate, 1, "default undo for sync effect is to do nothing");
+            t.same(fiber.value, 23, "first value was set");
+        }).
+        exec(K(17)).
+        effect((fiber, scheduler) => {
+            t.same(fiber.value, 17, "second value was set");
+            scheduler.setRateForFiber(fiber, -1);
+        });
+    run(fiber);
+    t.undefined(fiber.value, "value was unset");
+});
+
+test("Undo delay", t => {
+    const fiber = new Fiber().
+        delay(222).
+        effect((fiber, scheduler) => {
+            t.same(scheduler.now, 222, "delay elapsed");
+            scheduler.setRateForFiber(fiber, -2);
+        });
+    const scheduler = run(fiber);
+    t.same(scheduler.lastInstant, 333, "delay was undone (faster)");
+});

--- a/test/index.js
+++ b/test/index.js
@@ -2484,3 +2484,16 @@ test("Undo delay", t => {
     const scheduler = run(fiber);
     t.same(scheduler.lastInstant, 333, "delay was undone (faster)");
 });
+
+test("Undo event", t => {
+    const fiber = new Fiber().
+        event(window, "hello").
+        effect((fiber, scheduler) => {
+            t.same(scheduler.now, 222, "event was received after some time");
+            scheduler.setRateForFiber(fiber, -1);
+        });
+    const scheduler = run(fiber, new Scheduler(), 222);
+    window.dispatchEvent(new CustomEvent("hello"));
+    scheduler.clock.now = Infinity;
+    t.same(scheduler.lastInstant, 444, "event was undone");
+});


### PR DESCRIPTION
Provide default undo behaviour for basic opes: named, store, exec, effect, event, delay. Add the unops/unip properties to the fiber, and let the scheduler run those when rate is negative.