### PR TITLE
4Q06 Core: scheduler throws by default

### DIFF
--- a/lib/prelude.js
+++ b/lib/prelude.js
@@ -1,5 +1,7 @@
 import Fiber from "./fiber.js";
 import Scheduler from "./scheduler.js";
+import { on } from "./util.js";
+
 export { Fiber, Scheduler };
 
 // Event is an async command that waits for a specific event before continuing.
@@ -34,9 +36,11 @@ export const First = {
 };
 
 // Create a new scheduler and a main fiber, then start the clock. The fiber is
-// returned so that new instructions can be added immediately.
+// returned so that new instructions can be added immediately. Errors are also
+// reported to the console.
 export function run() {
     const scheduler = new Scheduler();
+    on(scheduler, "error", ({ error }) => { console.error(error.message ?? error); });
     scheduler.clock.start();
     const fiber = new Fiber();
     scheduler.scheduleFiber(fiber);


### PR DESCRIPTION
Actually make the prelude function `run` show errors to the console by default.