### PR TITLE
4V05 Dodo: update whitespace handling in interpreter

### DIFF
--- a/dodo/parser.js
+++ b/dodo/parser.js
@@ -163,7 +163,7 @@ function pushNewList(stack) {
 // FIXME 3I02 Dodo: Binary numbers
 // FIXME 3I03 Dodo: Hexadecimal numbers
 // FIXME 3I04 Dodo: Scientific notation for numbers
-function parseNumber(value) {
+export function parseNumber(value) {
     const match = value.match(/^[+-]?\d+(\.\d+)?$/);
     if (match) {
         return parseFloat(value);

--- a/test/dodo.js
+++ b/test/dodo.js
@@ -186,8 +186,7 @@ test("Interpreter: self-evaluating expression", t => {
 });
 
 test("Interpreter: self-evaluating expression", t => {
-    t.skip("4V05 Dodo: update whitespace handling in interpreter");
-    t.same(run("{ seq Hello, world! }"), "Hello, world!", "text");
+    t.same(run(`{ seq "Hello, world!" }`), "Hello, world!", "string");
 });
 
 test("Interpreter: variable", t => {
@@ -207,7 +206,6 @@ test("Interpreter: unquote special form", t => {
 });
 
 test("Interpreter: set! special form", t => {
-    t.skip("4V05 Dodo: update whitespace handling in interpreter");
     t.same(run("{ set! set! `23 }"), 23, "returns the new value");
     t.same(run("{ seq { set! set! `23 } `set! }"), 23, "after setting it");
     t.throws(() => run("{ set! x `23 }"), "can only set the value of a defined variable");
@@ -215,7 +213,6 @@ test("Interpreter: set! special form", t => {
 });
 
 test("Interpreter: define special form", t => {
-    t.skip("4V05 Dodo: update whitespace handling in interpreter");
     t.same(run("{ define x `23 }"), 23, "returns the new value");
     t.same(run("{ seq { define x `23 } `x }"), 23, "after setting it");
     t.throws(() => run("{ seq { define x `23 } { define x `17 } }"), "cannot redefine a value in the same scope");
@@ -223,16 +220,14 @@ test("Interpreter: define special form", t => {
 });
 
 test("Interpeter: if special form", t => {
-    t.skip("4V05 Dodo: update whitespace handling in interpreter");
     t.same(run("{ if `true `23 ko }"), 23, "predicate is true");
-    t.same(run("{ if false `23 ko }"), 23, "predicate is truthy (false as string)");
+    t.same(run("{ if \"false\" `23 ko }"), 23, "predicate is truthy (false as string)");
     t.same(run("{ if `0 `23 ko }"), 23, "predicate is truthy (0)");
     t.same(run("{ if `{} `23 ko }"), 23, "predicate is truthy (empty list)");
     t.same(run("{ if `false ko `23 }"), 23, "predicate is false");
 });
 
 test("Interpreter: application", t => {
-    t.skip("4V05 Dodo: update whitespace handling in interpreter");
     t.same(run("{ + `17 `23 `19 }"), 59, "+ (with arguments)");
     t.same(run("{ * }"), 1, "* (no argument)");
     t.throws(() => { run("{ ??? foo bar }"); }, "undefined value");
@@ -240,7 +235,6 @@ test("Interpreter: application", t => {
 });
 
 test("Interpreter: lambda special form", t => {
-    t.skip("4V05 Dodo: update whitespace handling in interpreter");
     t.typeof(run("{ lambda `{ x } { + `x `1 } }"), "function", "creates a function");
     t.typeof(run("{ λ x { + `x `1 } }"), "function", "short form (λ, single parameter)");
     t.same(run("{ { λ x { + `x `1 } } `17 }"), 18, "may be applied");
@@ -248,7 +242,61 @@ test("Interpreter: lambda special form", t => {
 });
 
 test("Interpreter: define for functions", t => {
-    t.skip("4V05 Dodo: update whitespace handling in interpreter");
     t.same(run("{ seq { define incr `{ x } { + `1 `x } } { incr `23 } }"), 24, "single parameter");
     t.same(run("{ seq { define !- `{ x y } { - `y `x } } { !- `17 `23 } }"), 6, "multiple parameters");
+});
+
+// 4V05 Dodo: update whitespace handling in interpreter
+
+test("Interpreter: self-evaluating expression (raw number)", t => {
+    t.same(run("{ seq 17 }"), 17, "number");
+});
+
+test("Interpreter: variable (raw)", t => {
+    t.typeof(run("{ seq unquote }"), "symbol", "defined variable");
+    t.true(run("{ seq true }"), "true variable");
+    t.same(run("{ seq false }"), false, "false variable");
+});
+
+test("Interpreter: undefined variable error (raw)", t => {
+    t.throws(() => run("{ seq foo }"), "throws");
+});
+
+test("Interpreter: set! special form (raw)", t => {
+    t.same(run("{ set! set! 23 }"), 23, "returns the new value");
+    t.same(run("{ seq { set! set! 23 } set! }"), 23, "after setting it");
+    t.throws(() => run("{ set! x 23 }"), "can only set the value of a defined variable");
+});
+
+test("Interpreter: define special form (raw)", t => {
+    t.same(run("{ define x 23 }"), 23, "returns the new value");
+    t.same(run("{ seq { define x 23 } x }"), 23, "after setting it");
+    t.throws(() => run("{ seq { define x 23 } { define x 17 } }"), "cannot redefine a value in the same scope");
+});
+
+test("Interpeter: if special form (raw)", t => {
+    t.same(run("{ if true 23 ko }"), 23, "predicate is true");
+    t.same(run("{ if \"false\" 23 ko }"), 23, "predicate is truthy (false as string)");
+    t.same(run("{ if 0 23 ko }"), 23, "predicate is truthy (0)");
+    t.same(run("{ if `{} 23 ko }"), 23, "predicate is truthy (empty list)");
+    t.same(run("{ if false ko 23 }"), 23, "predicate is false");
+});
+
+test("Interpreter: application (raw)", t => {
+    t.same(run("{ + 17 23 19 }"), 59, "+ (with arguments)");
+    t.same(run("{ * }"), 1, "* (no argument)");
+    t.throws(() => { run("{ ??? foo bar }"); }, "undefined value");
+    t.throws(() => { run("{ seq { define f 23 } { f 17 } }"); }, "not a function");
+});
+
+test("Interpreter: lambda special form (raw)", t => {
+    t.typeof(run("{ lambda `{ x } { + x 1 } }"), "function", "creates a function");
+    t.typeof(run("{ λ x { + x 1 } }"), "function", "short form (λ, single parameter)");
+    t.same(run("{ { λ x { + x 1 } } 17 }"), 18, "may be applied");
+    t.same(run("{ seq { define !- { lambda `{ x y } { - y x } } } { !- 17 23 } }"), 6, "define and call with arguments");
+});
+
+test("Interpreter: define for functions (raw)", t => {
+    t.same(run("{ seq { define incr `{ x } { + 1 x } } { incr 23 } }"), 24, "single parameter");
+    t.same(run("{ seq { define !- `{ x y } { - y x } } { !- 17 23 } }"), 6, "multiple parameters");
 });


### PR DESCRIPTION
Allow using raw numbers, strings and identifiers (still need `{} for lists; and unquoting still works).