### PR TITLE
4V04 Dodo: newlines and tabs in strings

### DIFF
--- a/dodo/parser.js
+++ b/dodo/parser.js
@@ -184,9 +184,9 @@ function setAttribute(stack, value) {
     }
 }
 
-// Unescape string content.
-// FIXME 4V04 Dodo: newlines and tabs in strings
-const unescape = x => x.replace(/\\(.)/gs, "$1");
+// Unescape string content; \n and \t are replaced by newline and tab; other
+// escaped characters are replaced by themselves (including actual newlines).
+const unescape = x => x.replace(/\\n/g, "\n").replace(/\\t/g, "\t").replace(/\\(.)/gs, "$1");
 
 // Create a special unquote element from a backtick.
 function unquote(value) {
@@ -287,7 +287,7 @@ class Parser {
                         break;
                     }
                     // Verbatim ("""Whatever "content""""), no escaping inside)
-                    match = this.input.match(/^"""(.*)"""/);
+                    match = this.input.match(/^"""(.*)"""/s);
                     if (match) {
                         this.input = this.input.substring(match[0].length);
                         this.line += match[0].match(/\n/g)?.length ?? 0;
@@ -295,8 +295,7 @@ class Parser {
                         break;
                     }
                     // String ("Hello, world!"); \u0022 = "
-                    // FIXME 4V04 Dodo: newlines and tabs in strings
-                    match = this.input.match(/^"((?:[^\u0022\\]|\\.)*)"/);
+                    match = this.input.match(/^"((?:[^\u0022\\\n]|\\.)*)"/s);
                     if (match) {
                         this.input = this.input.substring(match[0].length);
                         this.line += match[0].match(/\n/g)?.length ?? 0;
@@ -315,7 +314,7 @@ class Parser {
                     }
                     // Word (does not start with {}`"#, and does not contain
                     // unescaped space.
-                    match = this.input.match(/^((?:[^\s\{\}#\u0060\\]|\\.)+)/s);
+                    match = this.input.match(/^((?:[^\s\{\}#\u0022\u0060\\]|\\.)+)/s);
                     if (match) {
                         this.input = this.input.substring(match[0].length);
                         this.line += match[0].match(/\n/g)?.length ?? 0;

--- a/test/dodo.js
+++ b/test/dodo.js
@@ -155,6 +155,30 @@ test("Parser: verbatim string in content", t => {
     t.equal(consolidateText(root.content), [`"Hello, world!" (a string within a string)`], "consolidated");
 });
 
+// 4V04 Dodo: newlines and tabs in strings
+
+test("Parser: newline and tab", t => {
+    const { root } = parse(`{ p "Hello,\\tworld!\\n" }`);
+    t.equal(root.content, [new String("Hello,\tworld!\n")], "unescaped");
+});
+
+test("Parser: newline in string", t => {
+    t.throws(() => parse(`{ p "Hello,
+world!" }`), "error");
+});
+
+test("Parser: newline in string (escaped)", t => {
+    const { root } = parse(`{ p "Hello,\\
+world!" }`);
+    t.equal(root.content, [new String("Hello,\nworld!")], "unescaped");
+});
+
+test("Parser: newline in verbatim string", t => {
+    const { root } = parse(`{ p """Hello,
+world!""" }`);
+    t.equal(root.content, [new String("Hello,\nworld!")], "as is");
+});
+
 // 2K05 Dodo: eval
 
 test("Interpreter: self-evaluating expression", t => {


### PR DESCRIPTION
No more raw newlines in strings, but make sure that they are matched correctly in verbatim. Also allow \t and \n in strings for tabs and newlines.