### PR TITLE
4W07 Repeat can be removed from the core

### DIFF
--- a/examples/stopwatch.html
+++ b/examples/stopwatch.html
@@ -6,13 +6,9 @@
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <link rel="stylesheet" href="style.css"/>
         <script type="module">
-import { Fiber, Scheduler } from "../lib/unrated.js";
+import { run } from "../lib/shell.js";
 
-const scheduler = new Scheduler();
-scheduler.clock.start();
-scheduler.addEventListener("error", ({ detail: { error } }) => { console.error(error.message ?? error); });
-
-scheduler.scheduleFiber(new Fiber().
+run().
     sync((fiber, scheduler) => {
         fiber.scope.range = document.querySelector("input");
         fiber.scope.button = document.querySelector("button");
@@ -23,7 +19,7 @@ scheduler.scheduleFiber(new Fiber().
         sync(({ scope: { button } }) => { button.disabled = true; }).
         ramp(
             ({ scope: { range } }) => 1000 * range.value,
-            (p, fiber) => {
+            (p, fiber, scheduler) => {
                 const { progress, range } = fiber.scope;
                 progress.max = range.value;
                 progress.value = p * progress.max;
@@ -33,9 +29,7 @@ scheduler.scheduleFiber(new Fiber().
         ramp(333).
         ramp(111, (p, { scope: { progress } }) => { progress.value = (1 - p) * progress.max; }).
         sync(({ scope: { range, button } }) => { button.disabled = false; })
-    ),
-    0
-);
+    );
 
         </script>
     </head>

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -6,6 +6,38 @@ Fiber.prototype.macro = function(f) {
     return this;
 };
 
+// Repeat a child fiber. The optional delegate method `repeatShouldEnd`
+// should return true when the repetition should end and is called before
+// every iteration with the current iteration count (starting at 0 before
+// the first iteration begins).
+Fiber.prototype.repeat = function(f, delegate) {
+    const body = new Fiber();
+    this.
+        sync((fiber, scheduler) => {
+            if (delegate?.repeatShouldEnd?.call(delegate, 0, fiber, scheduler)) {
+                return;
+            }
+            scheduler.attachFiber(fiber, body);
+        }).
+        join({
+            iterationCount: 0,
+            childFiberDidJoin(child, scheduler) {
+                delegate?.childFiberDidJoin?.call(delegate, child, scheduler);
+                this.iterationCount += 1;
+                const fiber = child.parent;
+                if (delegate?.repeatShouldEnd?.call(delegate, this.iterationCount, fiber, scheduler)) {
+                    return;
+                }
+                scheduler.attachFiber(fiber, body);
+            }
+        });
+    if (typeof f === "function") {
+        f(body);
+        return this;
+    }
+    return body;
+};
+
 // Set a value in its original scope, or in the fiber’s own scope if it does
 // not appear in any scope.
 ScheduledFiber.prototype.setOriginalValue = function(name, value) {

--- a/lib/unrated.js
+++ b/lib/unrated.js
@@ -1,6 +1,8 @@
 // This is a minimal implementation of Epistrophy that does not include time
 // manipulation (fibers always have a rate of 1).
 
+import { extend, PriorityQueue, remove } from "./util.js";
+
 // The scheduler has a clock and schedule fibers. Create a scheduler with
 // `new Scheduler()`, schedule a fiber with `scheduler.schedulFiber(fiber, 0)`,
 // and start the clock `scheduler.clock.start()`.
@@ -51,11 +53,10 @@ export class Scheduler extends EventTarget {
     }
 
     // Cancel a fiber by setting its error.
-    // FIXME 4U05 Error propagation
     cancelFiber(fiber) {
         if (this.fibers.has(fiber) && fiber.cancel(this)) {
             if (fiber.joinDelegate) {
-                for (const child of fiber.joinDelegate.pending) {
+                for (const child of fiber.children) {
                     this.cancelFiber(child);
                 }
             } else if (fiber !== this.currentFiber) {
@@ -181,8 +182,8 @@ export class Scheduler extends EventTarget {
 }
 
 // Create a fiber with `new Fiber()` then add instructions with `async`,
-// `event`, `ever`, `join`, `ramp`, `repeat`, `spawn` and `sync`. These are
-// all chainable for convenience.
+// `event`, `ever`, `join`, `ramp`, `spawn` and `sync`. These can all be
+// chained for convenience.
 export class Fiber {
     constructor() {
         this.ops = [];
@@ -238,23 +239,6 @@ export class Fiber {
     ramp(dur, f) {
         this.ops.push(["ramp", this.everDepth > 0, dur, f]);
         return this;
-    }
-
-    // Repeat a child fiber. The optional delegate method `repeatShouldEnd`
-    // should return true when the repetition should end and is called before
-    // every iteration with the current iteration count (starting at 0 before
-    // the first iteration begins).
-    repeat(f, delegate) {
-        const body = new Fiber();
-        this.ops.push(
-            ["repeat", this.everDepth > 0, body, delegate],
-            ["loop", this.everDepth > 0]
-        );
-        if (typeof f === "function") {
-            f(body);
-            return this;
-        }
-        return body;
     }
 
     // Spawn a child fiber, calling `f` on the new fiber, or returning it
@@ -326,22 +310,18 @@ export class Fiber {
             return true;
         },
 
-        // Setup a join delegate with the current children marked as pending.
-        // Child fibers that end call their parent’s `childFiberDidEnd` method
-        // which eventually request the scheduler to resume the fiber when no
-        // pending fibers are left.
+        // Setup a join delegate and call its `fiberWillJoin` method then
+        // yield. Child fibers that end call their parent’s `childFiberDidEnd`
+        // method which eventually request the scheduler to resume the fiber
+        // when no child fibers are left. End immediately if no child fibers
+        // have been spawned.
         join(scheduler, delegate) {
             if (!this.children) {
                 return;
             }
-            this.joinDelegate = extend(delegate, { pending: new Set(this.children) });
+            this.joinDelegate = extend(delegate);
             delegate?.fiberWillJoin?.call(delegate, this, scheduler);
             return true;
-        },
-
-        // Jump back to the previous repeat instruction.
-        loop() {
-            this.ip -= 2;
         },
 
         // Get the ramp duration and register the ramp with the scheduler.
@@ -351,27 +331,6 @@ export class Fiber {
                 return scheduler.scheduleRamp(this, effectiveDuration, f);
             }
             throw Error("Ramp duration is not a positive number");
-        },
-
-        // Spawn the body fiber and setups a specific join delegate that counts
-        // iterations. The delegate `repeatShouldEnd` method is called before
-        // every iteration; if it returns true, do not spawn the fiber and skip
-        // over the following `loop` instruction.
-        repeat(scheduler, body, delegate) {
-            if (this.joinDelegate) {
-                this.joinDelegate.iteration += 1;
-            } else {
-                this.joinDelegate = extend(delegate, { iteration: 0 });
-            }
-            if (delegate?.repeatShouldEnd?.call(delegate, this.joinDelegate.iteration, this, scheduler)) {
-                delete this.joinDelegate;
-                // Skip the next instruction (loop) and do not yield.
-                this.ip += 1;
-            } else {
-                this.joinDelegate.pending = new Set([scheduler.attachFiber(this, body)]);
-                // Yield.
-                return true;
-            }
         },
 
         // Spawn a new instance of the child fiber and continue.
@@ -422,7 +381,6 @@ export class ScheduledFiber {
 
     // Cancel the fiber and resume, unless the current instruction is in an
     // ever block.
-    // FIXME 4U05 Error propagation
     cancel(scheduler) {
         this.error = Cancelled;
         if (!this.ops[this.ip - 1][1]) {
@@ -436,31 +394,30 @@ export class ScheduledFiber {
         return this.error === Cancelled;
     }
 
-    // When a child fiber ends, check with the join delegate whether this was
-    // the last pending child or not. If so, request the scheduler to resume
-    // execution.
+    // When a child fiber ends, call the join delegate’s `childFiberDidJoin`
+    // method, then check with the join delegate whether this was the last
+    // pending child or not. If so, request the scheduler to resume execution.
     childFiberDidEnd(fiber, scheduler) {
         if (!this.joinDelegate) {
             return;
         }
         this.now = scheduler.now - this.begin;
-        this.joinDelegate.pending.delete(fiber);
+        remove(this.children, fiber);
         const delegate = Object.getPrototypeOf(this.joinDelegate);
         delegate.childFiberDidJoin?.call(delegate, fiber, scheduler);
-        if (this.joinDelegate.pending.size === 0) {
-            if (!Object.hasOwn(this.joinDelegate, "iteration")) {
-                delete this.joinDelegate;
-            }
+        if (this.children.length === 0) {
+            delete this.joinDelegate;
             delete this.children;
             return true;
         }
     }
 
-    // Set the error and send a message from the scheduler.
+    // Set the error and send a message from the scheduler and cancel child
+    // fibers.
     errorWithMessage(scheduler, error) {
         this.error = error;
         if (this.joinDelegate && !this.ops[this.ip - 1][1]) {
-            for (const child of this.joinDelegate.pending) {
+            for (const child of this.children) {
                 scheduler.cancelFiber(child);
             }
         }
@@ -564,86 +521,4 @@ export class Clock {
             delete this.startTime;
         }
     }
-}
-
-// Extend a new instance of an object (or the empty object) with additional
-// properties.
-export const extend = (x, ...props) => Object.assign(x ? Object.create(x) : {}, ...props);
-
-// Priority queue implemented with a binary heap.
-export class PriorityQueue extends Array {
-
-    // Create a new priority queue with a comparison function to order elements
-    // (minimum queue by default).
-    constructor(cmp = (a, b) => a - b) {
-        super();
-        this.cmp = cmp;
-    }
-
-    // Insert a new element x in the queue maintaining the heap property.
-    insert(x) {
-        this.push(x);
-        for (let i = this.length - 1; i > 0;) {
-            const j = Math.floor((i - 1) / 2);
-            if (this.cmp(x, this[j]) >= 0) {
-                break;
-            }
-            this[i] = this[j];
-            this[j] = x;
-            i = j;
-        }
-        return x;
-    }
-
-    // Remove an element and return it, maintaining the heap property. By
-    // default, the first element is removed.
-    remove(at = 0) {
-        const n = this.length - 1;
-        if (n < 0) {
-            return;
-        }
-        const last = this.pop();
-        if (n === at) {
-            return last;
-        }
-        const removed = this[at];
-        this[at] = last;
-        for (let i = at;;) {
-            const j = 2 * i + 1;
-            if (j >= n) {
-                break;
-            }
-            const k = j + 1;
-            if (this.cmp(this[i], this[j]) <= 0) {
-                if (k >= n || this.cmp(this[i], this[k]) <= 0) {
-                    break;
-                }
-                this[i] = this[k];
-                this[k] = last;
-                i = k;
-            } else {
-                if (k >= n || this.cmp(this[j], this[k]) <= 0) {
-                    this[i] = this[j];
-                    this[j] = last;
-                    i = j;
-                } else if (k < n) {
-                    this[i] = this[k];
-                    this[k] = last;
-                    i = k;
-                } else {
-                    break;
-                }
-            }
-        }
-        return removed;
-    }
-}
-
-// Remove an element from an array.
-export const remove = (xs, x) => {
-    const index = xs.indexOf(x);
-    if (index < 0) {
-        throw Error("Cannot remove non-element of array");
-    }
-    xs.splice(index, 1)[0];
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -10,7 +10,7 @@ export const K = x => () => x;
 export const clamp = (x, min, max) => Math.min(Math.max(x, min), max);
 
 // Extend an object by creating a new one with additional properties.
-export const extend = (x, ...props) => Object.assign(Object.create(x), ...props);
+export const extend = (x, ...props) => Object.assign(x ? Object.create(x) : {}, ...props);
 
 // Test whether a function is declared as async.
 export const isAsync = f => Object.getPrototypeOf(f) === Object.getPrototypeOf(async function() {});


### PR DESCRIPTION
Move repeat to the shell, simplifying pending/children. Cars example is broken, to be fixed in 4H0H.